### PR TITLE
[FEAT] 홈/보관함 상세 api 연결

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "NATIVE_APP_KEY", properties["native.app.key"]
+        buildConfigField "String", "GROWTHOOK_BASE_URL", properties["growthook.base.url"]
 
         manifestPlaceholders["NATIVE_APP_KEY"] =
                 properties.getProperty("native.app.key.no.quotes")

--- a/app/src/main/java/com/growthook/aos/App.kt
+++ b/app/src/main/java/com/growthook/aos/App.kt
@@ -31,7 +31,7 @@ class App : Application() {
     private fun initFlipper() {
         SoLoader.init(this, false)
 
-        if (BuildConfig.DEBUG && FlipperUtils.shouldEnableFlipper(this)) {
+        if (FlipperUtils.shouldEnableFlipper(this)) {
             AndroidFlipperClient.getInstance(this).apply {
                 addPlugin(InspectorFlipperPlugin(this@App, DescriptorMapping.withDefaults()))
                 addPlugin(flipperNetworkPlugin)

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
@@ -2,9 +2,12 @@ package com.growthook.aos.data.datasource.remote
 
 import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
+import com.growthook.aos.data.model.response.ResponseGetDetailCaveDto
 
 interface CaveDataSource {
     suspend fun deleteCave(caveId: Int): ResponseDto
 
     suspend fun getCaves(memberId: Int): ResponseGetCavesDto
+
+    suspend fun getCaveDetail(memberId: Int, caveId: Int): ResponseGetDetailCaveDto
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
@@ -1,5 +1,6 @@
 package com.growthook.aos.data.datasource.remote
 
+import com.growthook.aos.data.model.request.RequestCaveModifyDto
 import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import com.growthook.aos.data.model.response.ResponseGetDetailCaveDto
@@ -10,4 +11,6 @@ interface CaveDataSource {
     suspend fun getCaves(memberId: Int): ResponseGetCavesDto
 
     suspend fun getCaveDetail(memberId: Int, caveId: Int): ResponseGetDetailCaveDto
+
+    suspend fun modifyCave(caveId: Int, request: RequestCaveModifyDto): ResponseDto
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
@@ -1,7 +1,10 @@
 package com.growthook.aos.data.datasource.remote
 
 import com.growthook.aos.data.model.response.BaseResponse
+import com.growthook.aos.data.model.response.ResponseGetCavesDto
 
 interface CaveDataSource {
     suspend fun deleteCave(caveId: Int): BaseResponse<Unit>
+
+    suspend fun getCaves(memberId: Int): BaseResponse<List<ResponseGetCavesDto>>
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
@@ -1,10 +1,10 @@
 package com.growthook.aos.data.datasource.remote
 
-import com.growthook.aos.data.model.response.ResponseDeleteCaveDto
+import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 
 interface CaveDataSource {
-    suspend fun deleteCave(caveId: Int): ResponseDeleteCaveDto
+    suspend fun deleteCave(caveId: Int): ResponseDto
 
     suspend fun getCaves(memberId: Int): ResponseGetCavesDto
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
@@ -1,10 +1,10 @@
 package com.growthook.aos.data.datasource.remote
 
-import com.growthook.aos.data.model.response.BaseResponse
+import com.growthook.aos.data.model.response.ResponseDeleteCaveDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 
 interface CaveDataSource {
-    suspend fun deleteCave(caveId: Int): BaseResponse<Unit>
+    suspend fun deleteCave(caveId: Int): ResponseDeleteCaveDto
 
-    suspend fun getCaves(memberId: Int): BaseResponse<List<ResponseGetCavesDto>>
+    suspend fun getCaves(memberId: Int): ResponseGetCavesDto
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/CaveDataSource.kt
@@ -1,0 +1,7 @@
+package com.growthook.aos.data.datasource.remote
+
+import com.growthook.aos.data.model.response.BaseResponse
+
+interface CaveDataSource {
+    suspend fun deleteCave(caveId: Int): BaseResponse<Unit>
+}

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/SeedDataSource.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/SeedDataSource.kt
@@ -1,0 +1,7 @@
+package com.growthook.aos.data.datasource.remote
+
+import com.growthook.aos.data.model.response.ResponseDto
+
+interface SeedDataSource {
+    suspend fun deleteSeed(seedId: Int): ResponseDto
+}

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/SeedDataSource.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/SeedDataSource.kt
@@ -1,7 +1,11 @@
 package com.growthook.aos.data.datasource.remote
 
+import com.growthook.aos.data.model.request.RequestSeedMoveDto
 import com.growthook.aos.data.model.response.ResponseDto
+import com.growthook.aos.data.model.response.ResponseMoveSeedDto
 
 interface SeedDataSource {
     suspend fun deleteSeed(seedId: Int): ResponseDto
+
+    suspend fun moveSeed(seedId: Int, request: RequestSeedMoveDto): ResponseMoveSeedDto
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
@@ -1,13 +1,13 @@
 package com.growthook.aos.data.datasource.remote.impl
 
 import com.growthook.aos.data.datasource.remote.CaveDataSource
-import com.growthook.aos.data.model.response.ResponseDeleteCaveDto
+import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import com.growthook.aos.data.service.CaveService
 import javax.inject.Inject
 
 class CaveDataSourceImpl @Inject constructor(private val apiService: CaveService) : CaveDataSource {
-    override suspend fun deleteCave(caveId: Int): ResponseDeleteCaveDto =
+    override suspend fun deleteCave(caveId: Int): ResponseDto =
         apiService.deleteCave(caveId)
 
     override suspend fun getCaves(memberId: Int): ResponseGetCavesDto =

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
@@ -2,9 +2,11 @@ package com.growthook.aos.data.datasource.remote.impl
 
 import com.growthook.aos.data.datasource.remote.CaveDataSource
 import com.growthook.aos.data.model.response.BaseResponse
+import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import com.growthook.aos.data.service.CaveService
 import javax.inject.Inject
 
 class CaveDataSourceImpl @Inject constructor(private val apiService: CaveService) : CaveDataSource {
     override suspend fun deleteCave(caveId: Int): BaseResponse<Unit> = apiService.deleteCave(caveId)
+    override suspend fun getCaves(memberId: Int): BaseResponse<List<ResponseGetCavesDto>> = apiService.getCaves(memberId)
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.growthook.aos.data.datasource.remote.impl
 import com.growthook.aos.data.datasource.remote.CaveDataSource
 import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
+import com.growthook.aos.data.model.response.ResponseGetDetailCaveDto
 import com.growthook.aos.data.service.CaveService
 import javax.inject.Inject
 
@@ -12,4 +13,7 @@ class CaveDataSourceImpl @Inject constructor(private val apiService: CaveService
 
     override suspend fun getCaves(memberId: Int): ResponseGetCavesDto =
         apiService.getCaves(memberId)
+
+    override suspend fun getCaveDetail(memberId: Int, caveId: Int): ResponseGetDetailCaveDto =
+        apiService.getCaveDetail(memberId, caveId)
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.growthook.aos.data.datasource.remote.impl
 
 import com.growthook.aos.data.datasource.remote.CaveDataSource
+import com.growthook.aos.data.model.request.RequestCaveModifyDto
 import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import com.growthook.aos.data.model.response.ResponseGetDetailCaveDto
@@ -16,4 +17,7 @@ class CaveDataSourceImpl @Inject constructor(private val apiService: CaveService
 
     override suspend fun getCaveDetail(memberId: Int, caveId: Int): ResponseGetDetailCaveDto =
         apiService.getCaveDetail(memberId, caveId)
+
+    override suspend fun modifyCave(caveId: Int, request: RequestCaveModifyDto): ResponseDto =
+        apiService.modifyCave(caveId, request)
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
@@ -1,0 +1,10 @@
+package com.growthook.aos.data.datasource.remote.impl
+
+import com.growthook.aos.data.datasource.remote.CaveDataSource
+import com.growthook.aos.data.model.response.BaseResponse
+import com.growthook.aos.data.service.CaveService
+import javax.inject.Inject
+
+class CaveDataSourceImpl @Inject constructor(private val apiService: CaveService) : CaveDataSource {
+    override suspend fun deleteCave(caveId: Int): BaseResponse<Unit> = apiService.deleteCave(caveId)
+}

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/CaveDataSourceImpl.kt
@@ -1,12 +1,15 @@
 package com.growthook.aos.data.datasource.remote.impl
 
 import com.growthook.aos.data.datasource.remote.CaveDataSource
-import com.growthook.aos.data.model.response.BaseResponse
+import com.growthook.aos.data.model.response.ResponseDeleteCaveDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import com.growthook.aos.data.service.CaveService
 import javax.inject.Inject
 
 class CaveDataSourceImpl @Inject constructor(private val apiService: CaveService) : CaveDataSource {
-    override suspend fun deleteCave(caveId: Int): BaseResponse<Unit> = apiService.deleteCave(caveId)
-    override suspend fun getCaves(memberId: Int): BaseResponse<List<ResponseGetCavesDto>> = apiService.getCaves(memberId)
+    override suspend fun deleteCave(caveId: Int): ResponseDeleteCaveDto =
+        apiService.deleteCave(caveId)
+
+    override suspend fun getCaves(memberId: Int): ResponseGetCavesDto =
+        apiService.getCaves(memberId)
 }

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/SeedDataSourceImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/SeedDataSourceImpl.kt
@@ -1,0 +1,10 @@
+package com.growthook.aos.data.datasource.remote.impl
+
+import com.growthook.aos.data.datasource.remote.SeedDataSource
+import com.growthook.aos.data.model.response.ResponseDto
+import com.growthook.aos.data.service.SeedService
+import javax.inject.Inject
+
+class SeedDataSourceImpl @Inject constructor(private val apiService: SeedService) : SeedDataSource {
+    override suspend fun deleteSeed(seedId: Int): ResponseDto = apiService.deleteSeed(seedId)
+}

--- a/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/SeedDataSourceImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/datasource/remote/impl/SeedDataSourceImpl.kt
@@ -1,10 +1,14 @@
 package com.growthook.aos.data.datasource.remote.impl
 
 import com.growthook.aos.data.datasource.remote.SeedDataSource
+import com.growthook.aos.data.model.request.RequestSeedMoveDto
 import com.growthook.aos.data.model.response.ResponseDto
+import com.growthook.aos.data.model.response.ResponseMoveSeedDto
 import com.growthook.aos.data.service.SeedService
 import javax.inject.Inject
 
 class SeedDataSourceImpl @Inject constructor(private val apiService: SeedService) : SeedDataSource {
     override suspend fun deleteSeed(seedId: Int): ResponseDto = apiService.deleteSeed(seedId)
+    override suspend fun moveSeed(seedId: Int, request: RequestSeedMoveDto): ResponseMoveSeedDto =
+        apiService.moveSeed(seedId, request)
 }

--- a/app/src/main/java/com/growthook/aos/data/entity/User.kt
+++ b/app/src/main/java/com/growthook/aos/data/entity/User.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class User(
     val name: String? = null,
+    val memberId:Int? = null
 )

--- a/app/src/main/java/com/growthook/aos/data/model/request/RequestCaveModifyDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/request/RequestCaveModifyDto.kt
@@ -1,0 +1,14 @@
+package com.growthook.aos.data.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestCaveModifyDto(
+    @SerialName("name")
+    val name: String,
+    @SerialName("introduction")
+    val introduction: String,
+    @SerialName("isShared")
+    val isShared: Boolean,
+)

--- a/app/src/main/java/com/growthook/aos/data/model/request/RequestSeedMoveDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/request/RequestSeedMoveDto.kt
@@ -1,0 +1,10 @@
+package com.growthook.aos.data.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestSeedMoveDto(
+    @SerialName("caveId")
+    val caveId: Int,
+)

--- a/app/src/main/java/com/growthook/aos/data/model/response/BaseResponse.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/BaseResponse.kt
@@ -7,5 +7,5 @@ data class BaseResponse<T>(
     val status: Int,
     val success: Boolean,
     val message: String,
-    val data: T? = null,
+    val data: T,
 )

--- a/app/src/main/java/com/growthook/aos/data/model/response/BaseResponse.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/BaseResponse.kt
@@ -1,0 +1,11 @@
+package com.growthook.aos.data.model.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BaseResponse<T>(
+    val status: Int,
+    val success: Boolean,
+    val message: String,
+    val data: T? = null,
+)

--- a/app/src/main/java/com/growthook/aos/data/model/response/ResponseDeleteCaveDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/ResponseDeleteCaveDto.kt
@@ -1,11 +1,14 @@
 package com.growthook.aos.data.model.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class BaseResponse<T>(
+data class ResponseDeleteCaveDto(
+    @SerialName("status")
     val status: Int,
+    @SerialName("success")
     val success: Boolean,
+    @SerialName("message")
     val message: String,
-    val data: T,
 )

--- a/app/src/main/java/com/growthook/aos/data/model/response/ResponseDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/ResponseDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ResponseDeleteCaveDto(
+data class ResponseDto(
     @SerialName("status")
     val status: Int,
     @SerialName("success")

--- a/app/src/main/java/com/growthook/aos/data/model/response/ResponseGetCavesDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/ResponseGetCavesDto.kt
@@ -1,0 +1,15 @@
+package com.growthook.aos.data.model.response
+
+import com.growthook.aos.domain.entity.Cave
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseGetCavesDto(
+    @SerialName("caveId")
+    val caveId: Int,
+    @SerialName("caveName")
+    val caveName: String,
+) {
+    fun toCave() = Cave(caveId, caveName)
+}

--- a/app/src/main/java/com/growthook/aos/data/model/response/ResponseGetCavesDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/ResponseGetCavesDto.kt
@@ -6,10 +6,22 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ResponseGetCavesDto(
-    @SerialName("caveId")
-    val caveId: Int,
-    @SerialName("caveName")
-    val caveName: String,
+    @SerialName("status")
+    val status: Int,
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: List<Caves>,
 ) {
-    fun toCave() = Cave(caveId, caveName)
+    @Serializable
+    data class Caves(
+        @SerialName("caveId")
+        val caveId: Int,
+        @SerialName("caveName")
+        val caveName: String,
+    )
+
+    fun toCaves() = data.map { cave -> Cave(cave.caveId, cave.caveName) }
 }

--- a/app/src/main/java/com/growthook/aos/data/model/response/ResponseGetDetailCaveDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/ResponseGetDetailCaveDto.kt
@@ -1,0 +1,31 @@
+package com.growthook.aos.data.model.response
+
+import com.growthook.aos.domain.entity.CaveDetail
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseGetDetailCaveDto(
+    @SerialName("status")
+    val status: Int,
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: DetailCave,
+) {
+    @Serializable
+    data class DetailCave(
+        @SerialName("caveName")
+        val caveName: String,
+        @SerialName("introduction")
+        val introduction: String,
+        @SerialName("nickname")
+        val nickname: String,
+        @SerialName("isShared")
+        val isShared: Boolean,
+    )
+
+    fun toCaveDetail() = CaveDetail(data.caveName, data.introduction, data.nickname, data.isShared)
+}

--- a/app/src/main/java/com/growthook/aos/data/model/response/ResponseGetDetailCaveDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/ResponseGetDetailCaveDto.kt
@@ -27,5 +27,5 @@ data class ResponseGetDetailCaveDto(
         val isShared: Boolean,
     )
 
-    fun toCaveDetail() = CaveDetail(data.caveName, data.introduction, data.nickname, data.isShared)
+    fun toCaveDetail() = CaveDetail(data.caveName, data.introduction, data.isShared)
 }

--- a/app/src/main/java/com/growthook/aos/data/model/response/ResponseMoveSeedDto.kt
+++ b/app/src/main/java/com/growthook/aos/data/model/response/ResponseMoveSeedDto.kt
@@ -1,0 +1,25 @@
+package com.growthook.aos.data.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseMoveSeedDto(
+    @SerialName("status")
+    val status: Int,
+    @SerialName("success")
+    val success: Boolean,
+    @SerialName("message")
+    val message: String,
+    @SerialName("data")
+    val data: CaveDto,
+) {
+
+    @Serializable
+    data class CaveDto(
+        @SerialName("caveId")
+        val caveId: Int,
+        @SerialName("caveName")
+        val caveName: String,
+    )
+}

--- a/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
@@ -12,6 +12,6 @@ class CaveRepositoryImpl @Inject constructor(private val caveDataSource: CaveDat
     }
 
     override suspend fun getCaves(memberId: Int): Result<List<Cave>> = runCatching {
-        caveDataSource.getCaves(memberId).data.map { cave -> cave.toCave() }
+        caveDataSource.getCaves(memberId).toCaves()
     }
 }

--- a/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.growthook.aos.data.repository
 
 import com.growthook.aos.data.datasource.remote.CaveDataSource
 import com.growthook.aos.domain.entity.Cave
+import com.growthook.aos.domain.entity.CaveDetail
 import com.growthook.aos.domain.repository.CaveRepository
 import javax.inject.Inject
 
@@ -14,4 +15,9 @@ class CaveRepositoryImpl @Inject constructor(private val caveDataSource: CaveDat
     override suspend fun getCaves(memberId: Int): Result<List<Cave>> = runCatching {
         caveDataSource.getCaves(memberId).toCaves()
     }
+
+    override suspend fun getCaveDetail(memberId: Int, caveId: Int): Result<CaveDetail> =
+        runCatching {
+            caveDataSource.getCaveDetail(memberId, caveId).toCaveDetail()
+        }
 }

--- a/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.growthook.aos.data.repository
 
 import com.growthook.aos.data.datasource.remote.CaveDataSource
+import com.growthook.aos.data.model.request.RequestCaveModifyDto
 import com.growthook.aos.domain.entity.Cave
 import com.growthook.aos.domain.entity.CaveDetail
 import com.growthook.aos.domain.repository.CaveRepository
@@ -20,4 +21,13 @@ class CaveRepositoryImpl @Inject constructor(private val caveDataSource: CaveDat
         runCatching {
             caveDataSource.getCaveDetail(memberId, caveId).toCaveDetail()
         }
+
+    override suspend fun modifyCave(caveId: Int, name: String, introduction: String): Result<Unit> =
+        runCatching {
+            caveDataSource.modifyCave(caveId, RequestCaveModifyDto(name, introduction, FIXED_VALUE))
+        }
+
+    companion object {
+        private const val FIXED_VALUE = true
+    }
 }

--- a/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
@@ -1,0 +1,11 @@
+package com.growthook.aos.data.repository
+
+import com.growthook.aos.data.datasource.remote.CaveDataSource
+import com.growthook.aos.domain.repository.CaveRepository
+import javax.inject.Inject
+
+class CaveRepositoryImpl @Inject constructor(private val caveDataSource: CaveDataSource) :CaveRepository {
+    override suspend fun deleteCave(caveId: Int): Result<Unit> = kotlin.runCatching {
+        caveDataSource.deleteCave(caveId)
+    }
+}

--- a/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/repository/CaveRepositoryImpl.kt
@@ -1,11 +1,17 @@
 package com.growthook.aos.data.repository
 
 import com.growthook.aos.data.datasource.remote.CaveDataSource
+import com.growthook.aos.domain.entity.Cave
 import com.growthook.aos.domain.repository.CaveRepository
 import javax.inject.Inject
 
-class CaveRepositoryImpl @Inject constructor(private val caveDataSource: CaveDataSource) :CaveRepository {
-    override suspend fun deleteCave(caveId: Int): Result<Unit> = kotlin.runCatching {
+class CaveRepositoryImpl @Inject constructor(private val caveDataSource: CaveDataSource) :
+    CaveRepository {
+    override suspend fun deleteCave(caveId: Int): Result<Unit> = runCatching {
         caveDataSource.deleteCave(caveId)
+    }
+
+    override suspend fun getCaves(memberId: Int): Result<List<Cave>> = runCatching {
+        caveDataSource.getCaves(memberId).data.map { cave -> cave.toCave() }
     }
 }

--- a/app/src/main/java/com/growthook/aos/data/repository/SeedRepositoryImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/repository/SeedRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.growthook.aos.data.repository
 
 import com.growthook.aos.data.datasource.remote.SeedDataSource
+import com.growthook.aos.data.model.request.RequestSeedMoveDto
 import com.growthook.aos.domain.repository.SeedRepository
 import javax.inject.Inject
 
@@ -8,5 +9,9 @@ class SeedRepositoryImpl @Inject constructor(private val seedDataSource: SeedDat
     SeedRepository {
     override suspend fun deleteSeed(seedId: Int): Result<Unit> = runCatching {
         seedDataSource.deleteSeed(seedId)
+    }
+
+    override suspend fun moveSeed(seedId: Int, toMoveCaveId: Int): Result<Unit> = runCatching {
+        seedDataSource.moveSeed(seedId, RequestSeedMoveDto(toMoveCaveId))
     }
 }

--- a/app/src/main/java/com/growthook/aos/data/repository/SeedRepositoryImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/repository/SeedRepositoryImpl.kt
@@ -1,0 +1,12 @@
+package com.growthook.aos.data.repository
+
+import com.growthook.aos.data.datasource.remote.SeedDataSource
+import com.growthook.aos.domain.repository.SeedRepository
+import javax.inject.Inject
+
+class SeedRepositoryImpl @Inject constructor(private val seedDataSource: SeedDataSource) :
+    SeedRepository {
+    override suspend fun deleteSeed(seedId: Int): Result<Unit> = runCatching {
+        seedDataSource.deleteSeed(seedId)
+    }
+}

--- a/app/src/main/java/com/growthook/aos/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/growthook/aos/data/repository/UserRepositoryImpl.kt
@@ -8,8 +8,8 @@ import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(private val dataStore: DataStore<User>) :
     UserRepository {
-    override suspend fun setUserInfo(userName: String) {
-        dataStore.updateData { User(userName) }
+    override suspend fun setUserInfo(userName: String, memberId: Int) {
+        dataStore.updateData { User(userName, memberId) }
     }
 
     override suspend fun getUserInfo(): User = dataStore.data.first()

--- a/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
@@ -1,6 +1,6 @@
 package com.growthook.aos.data.service
 
-import com.growthook.aos.data.model.response.BaseResponse
+import com.growthook.aos.data.model.response.ResponseDeleteCaveDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -11,10 +11,10 @@ interface CaveService {
     @DELETE("api/v1/cave/{caveId}")
     suspend fun deleteCave(
         @Path("caveId") caveId: Int,
-    ): BaseResponse<Unit>
+    ): ResponseDeleteCaveDto
 
     @GET("api/v1/member/{memberId}/cave/all")
     suspend fun getCaves(
         @Path("memberId") memberId: Int,
-    ): BaseResponse<List<ResponseGetCavesDto>>
+    ): ResponseGetCavesDto
 }

--- a/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
@@ -1,6 +1,6 @@
 package com.growthook.aos.data.service
 
-import com.growthook.aos.data.model.response.ResponseDeleteCaveDto
+import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -11,7 +11,7 @@ interface CaveService {
     @DELETE("api/v1/cave/{caveId}")
     suspend fun deleteCave(
         @Path("caveId") caveId: Int,
-    ): ResponseDeleteCaveDto
+    ): ResponseDto
 
     @GET("api/v1/member/{memberId}/cave/all")
     suspend fun getCaves(

--- a/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
@@ -1,3 +1,13 @@
 package com.growthook.aos.data.service
 
-interface CaveService
+import com.growthook.aos.data.model.response.BaseResponse
+import retrofit2.http.DELETE
+import retrofit2.http.Path
+
+interface CaveService {
+
+    @DELETE("api/v1/cave/{caveId}")
+    suspend fun deleteCave(
+        @Path("caveId") caveId: Int,
+    ): BaseResponse<Unit>
+}

--- a/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
@@ -1,0 +1,3 @@
+package com.growthook.aos.data.service
+
+interface CaveService

--- a/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
@@ -2,6 +2,7 @@ package com.growthook.aos.data.service
 
 import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
+import com.growthook.aos.data.model.response.ResponseGetDetailCaveDto
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -17,4 +18,10 @@ interface CaveService {
     suspend fun getCaves(
         @Path("memberId") memberId: Int,
     ): ResponseGetCavesDto
+
+    @GET("api/v1/member/{memberId}/cave/{caveId}/detail")
+    suspend fun getCaveDetail(
+        @Path("memberId") memberId: Int,
+        @Path("caveId") caveId: Int,
+    ): ResponseGetDetailCaveDto
 }

--- a/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
@@ -1,7 +1,9 @@
 package com.growthook.aos.data.service
 
 import com.growthook.aos.data.model.response.BaseResponse
+import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import retrofit2.http.DELETE
+import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface CaveService {
@@ -10,4 +12,9 @@ interface CaveService {
     suspend fun deleteCave(
         @Path("caveId") caveId: Int,
     ): BaseResponse<Unit>
+
+    @GET("api/v1/member/{memberId}/cave/all")
+    suspend fun getCaves(
+        @Path("memberId") memberId: Int,
+    ): BaseResponse<List<ResponseGetCavesDto>>
 }

--- a/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/CaveService.kt
@@ -1,10 +1,13 @@
 package com.growthook.aos.data.service
 
+import com.growthook.aos.data.model.request.RequestCaveModifyDto
 import com.growthook.aos.data.model.response.ResponseDto
 import com.growthook.aos.data.model.response.ResponseGetCavesDto
 import com.growthook.aos.data.model.response.ResponseGetDetailCaveDto
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.Path
 
 interface CaveService {
@@ -24,4 +27,10 @@ interface CaveService {
         @Path("memberId") memberId: Int,
         @Path("caveId") caveId: Int,
     ): ResponseGetDetailCaveDto
+
+    @PATCH("api/v1/cave/{caveId}")
+    suspend fun modifyCave(
+        @Path("caveId") caveId: Int,
+        @Body request: RequestCaveModifyDto,
+    ): ResponseDto
 }

--- a/app/src/main/java/com/growthook/aos/data/service/SeedService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/SeedService.kt
@@ -1,7 +1,11 @@
 package com.growthook.aos.data.service
 
+import com.growthook.aos.data.model.request.RequestSeedMoveDto
 import com.growthook.aos.data.model.response.ResponseDto
+import com.growthook.aos.data.model.response.ResponseMoveSeedDto
+import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface SeedService {
@@ -10,4 +14,10 @@ interface SeedService {
     suspend fun deleteSeed(
         @Path("seedId") seedId: Int,
     ): ResponseDto
+
+    @POST("api/v1/seed/{seedId}/move")
+    suspend fun moveSeed(
+        @Path("seedId") seedId: Int,
+        @Body request: RequestSeedMoveDto,
+    ): ResponseMoveSeedDto
 }

--- a/app/src/main/java/com/growthook/aos/data/service/SeedService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/SeedService.kt
@@ -6,7 +6,7 @@ import retrofit2.http.Path
 
 interface SeedService {
 
-    @DELETE("api/v1/seed/@{seedId}")
+    @DELETE("api/v1/seed/{seedId}")
     suspend fun deleteSeed(
         @Path("seedId") seedId: Int,
     ): ResponseDto

--- a/app/src/main/java/com/growthook/aos/data/service/SeedService.kt
+++ b/app/src/main/java/com/growthook/aos/data/service/SeedService.kt
@@ -1,0 +1,13 @@
+package com.growthook.aos.data.service
+
+import com.growthook.aos.data.model.response.ResponseDto
+import retrofit2.http.DELETE
+import retrofit2.http.Path
+
+interface SeedService {
+
+    @DELETE("api/v1/seed/@{seedId}")
+    suspend fun deleteSeed(
+        @Path("seedId") seedId: Int,
+    ): ResponseDto
+}

--- a/app/src/main/java/com/growthook/aos/di/ApiModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/ApiModule.kt
@@ -3,11 +3,13 @@ package com.growthook.aos.di
 import com.growthook.aos.data.service.CaveService
 import dagger.Module
 import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import javax.inject.Singleton
 
 @Module
-@Singleton
+@InstallIn(SingletonComponent::class)
 object ApiModule {
 
     @Provides

--- a/app/src/main/java/com/growthook/aos/di/ApiModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/ApiModule.kt
@@ -1,6 +1,7 @@
 package com.growthook.aos.di
 
 import com.growthook.aos.data.service.CaveService
+import com.growthook.aos.data.service.SeedService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,4 +17,9 @@ object ApiModule {
     @Singleton
     fun provideCaveService(@GrowthookRetrofit retrofit: Retrofit): CaveService =
         retrofit.create(CaveService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSeedService(@GrowthookRetrofit retrofit: Retrofit): SeedService =
+        retrofit.create(SeedService::class.java)
 }

--- a/app/src/main/java/com/growthook/aos/di/ApiModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/ApiModule.kt
@@ -1,0 +1,17 @@
+package com.growthook.aos.di
+
+import com.growthook.aos.data.service.CaveService
+import dagger.Module
+import dagger.Provides
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@Singleton
+object ApiModule {
+
+    @Provides
+    @Singleton
+    fun provideCaveService(@GrowthookRetrofit retrofit: Retrofit): CaveService =
+        retrofit.create(CaveService::class.java)
+}

--- a/app/src/main/java/com/growthook/aos/di/DataSourceModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/DataSourceModule.kt
@@ -1,0 +1,18 @@
+package com.growthook.aos.di
+
+import com.growthook.aos.data.datasource.remote.CaveDataSource
+import com.growthook.aos.data.datasource.remote.impl.CaveDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+
+    @Singleton
+    @Binds
+    abstract fun providesCaveDataSource(dataSourceImpl: CaveDataSourceImpl): CaveDataSource
+}

--- a/app/src/main/java/com/growthook/aos/di/DataSourceModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/DataSourceModule.kt
@@ -1,7 +1,9 @@
 package com.growthook.aos.di
 
 import com.growthook.aos.data.datasource.remote.CaveDataSource
+import com.growthook.aos.data.datasource.remote.SeedDataSource
 import com.growthook.aos.data.datasource.remote.impl.CaveDataSourceImpl
+import com.growthook.aos.data.datasource.remote.impl.SeedDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -15,4 +17,8 @@ abstract class DataSourceModule {
     @Singleton
     @Binds
     abstract fun providesCaveDataSource(dataSourceImpl: CaveDataSourceImpl): CaveDataSource
+
+    @Singleton
+    @Binds
+    abstract fun providesSeedDataSource(dataSourceImpl: SeedDataSourceImpl): SeedDataSource
 }

--- a/app/src/main/java/com/growthook/aos/di/RepositoryModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.growthook.aos.di
 
+import com.growthook.aos.data.repository.CaveRepositoryImpl
 import com.growthook.aos.data.repository.TokenRepositoryImpl
 import com.growthook.aos.data.repository.UserRepositoryImpl
+import com.growthook.aos.domain.repository.CaveRepository
 import com.growthook.aos.domain.repository.TokenRepository
 import com.growthook.aos.domain.repository.UserRepository
 import dagger.Binds
@@ -21,4 +23,8 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun providesUserRepository(repoImpl: UserRepositoryImpl): UserRepository
+
+    @Singleton
+    @Binds
+    abstract fun providesCaveRepository(repoImpl: CaveRepositoryImpl): CaveRepository
 }

--- a/app/src/main/java/com/growthook/aos/di/RepositoryModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/RepositoryModule.kt
@@ -1,9 +1,11 @@
 package com.growthook.aos.di
 
 import com.growthook.aos.data.repository.CaveRepositoryImpl
+import com.growthook.aos.data.repository.SeedRepositoryImpl
 import com.growthook.aos.data.repository.TokenRepositoryImpl
 import com.growthook.aos.data.repository.UserRepositoryImpl
 import com.growthook.aos.domain.repository.CaveRepository
+import com.growthook.aos.domain.repository.SeedRepository
 import com.growthook.aos.domain.repository.TokenRepository
 import com.growthook.aos.domain.repository.UserRepository
 import dagger.Binds
@@ -27,4 +29,8 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun providesCaveRepository(repoImpl: CaveRepositoryImpl): CaveRepository
+
+    @Singleton
+    @Binds
+    abstract fun providesSeedRepository(repoImpl: SeedRepositoryImpl): SeedRepository
 }

--- a/app/src/main/java/com/growthook/aos/di/RetrofitModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/RetrofitModule.kt
@@ -1,7 +1,6 @@
 package com.growthook.aos.di
 
 import android.util.Log
-import com.facebook.flipper.plugins.network.BuildConfig
 import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import com.growthook.aos.util.extension.isJsonArray
@@ -34,9 +33,7 @@ object RetrofitModule {
     ): OkHttpClient =
         OkHttpClient.Builder().apply {
             addInterceptor(loggingInterceptor)
-            if (BuildConfig.DEBUG) {
-                addNetworkInterceptor(FlipperOkhttpInterceptor(networkFlipperPlugin))
-            }
+            addNetworkInterceptor(FlipperOkhttpInterceptor(networkFlipperPlugin))
         }.build()
 
     @Singleton

--- a/app/src/main/java/com/growthook/aos/di/RetrofitModule.kt
+++ b/app/src/main/java/com/growthook/aos/di/RetrofitModule.kt
@@ -23,8 +23,8 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object RetrofitModule {
-    // TODO base url 나오면 로컬 프로퍼티에 저장해서 BuildConfig 호출
-    private const val GROWTHOOK_BASE_URL = ""
+
+    private const val GROWTHOOK_BASE_URL = com.growthook.aos.BuildConfig.GROWTHOOK_BASE_URL
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/growthook/aos/domain/entity/CaveDetail.kt
+++ b/app/src/main/java/com/growthook/aos/domain/entity/CaveDetail.kt
@@ -3,6 +3,5 @@ package com.growthook.aos.domain.entity
 data class CaveDetail(
     val caveName: String,
     val introduction: String,
-    val nickname: String,
     val isShared: Boolean,
 )

--- a/app/src/main/java/com/growthook/aos/domain/entity/CaveDetail.kt
+++ b/app/src/main/java/com/growthook/aos/domain/entity/CaveDetail.kt
@@ -1,0 +1,8 @@
+package com.growthook.aos.domain.entity
+
+data class CaveDetail(
+    val caveName: String,
+    val introduction: String,
+    val nickname: String,
+    val isShared: Boolean,
+)

--- a/app/src/main/java/com/growthook/aos/domain/repository/CaveRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/CaveRepository.kt
@@ -10,4 +10,6 @@ interface CaveRepository {
     suspend fun getCaves(memberId: Int): Result<List<Cave>>
 
     suspend fun getCaveDetail(memberId: Int, caveId: Int): Result<CaveDetail>
+
+    suspend fun modifyCave(caveId: Int, name: String, introduction: String): Result<Unit>
 }

--- a/app/src/main/java/com/growthook/aos/domain/repository/CaveRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/CaveRepository.kt
@@ -1,10 +1,13 @@
 package com.growthook.aos.domain.repository
 
 import com.growthook.aos.domain.entity.Cave
+import com.growthook.aos.domain.entity.CaveDetail
 
 interface CaveRepository {
 
     suspend fun deleteCave(caveId: Int): Result<Unit>
 
     suspend fun getCaves(memberId: Int): Result<List<Cave>>
+
+    suspend fun getCaveDetail(memberId: Int, caveId: Int): Result<CaveDetail>
 }

--- a/app/src/main/java/com/growthook/aos/domain/repository/CaveRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/CaveRepository.kt
@@ -1,6 +1,10 @@
 package com.growthook.aos.domain.repository
 
+import com.growthook.aos.domain.entity.Cave
+
 interface CaveRepository {
 
     suspend fun deleteCave(caveId: Int): Result<Unit>
+
+    suspend fun getCaves(memberId: Int): Result<List<Cave>>
 }

--- a/app/src/main/java/com/growthook/aos/domain/repository/CaveRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/CaveRepository.kt
@@ -1,0 +1,6 @@
+package com.growthook.aos.domain.repository
+
+interface CaveRepository {
+
+    suspend fun deleteCave(caveId: Int): Result<Unit>
+}

--- a/app/src/main/java/com/growthook/aos/domain/repository/InsightRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/InsightRepository.kt
@@ -1,3 +1,0 @@
-package com.growthook.aos.domain.repository
-
-interface InsightRepository

--- a/app/src/main/java/com/growthook/aos/domain/repository/SeedRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/SeedRepository.kt
@@ -3,4 +3,6 @@ package com.growthook.aos.domain.repository
 interface SeedRepository {
 
     suspend fun deleteSeed(seedId: Int): Result<Unit>
+
+    suspend fun moveSeed(seedId: Int, toMoveCaveId: Int): Result<Unit>
 }

--- a/app/src/main/java/com/growthook/aos/domain/repository/SeedRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/SeedRepository.kt
@@ -1,0 +1,6 @@
+package com.growthook.aos.domain.repository
+
+interface SeedRepository {
+
+    suspend fun deleteSeed(seedId: Int): Result<Unit>
+}

--- a/app/src/main/java/com/growthook/aos/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/UserRepository.kt
@@ -4,6 +4,6 @@ import com.growthook.aos.data.entity.User
 
 interface UserRepository {
 
-    suspend fun setUserInfo(userName: String, memberId:Int)
+    suspend fun setUserInfo(userName: String, memberId: Int)
     suspend fun getUserInfo(): User
 }

--- a/app/src/main/java/com/growthook/aos/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/growthook/aos/domain/repository/UserRepository.kt
@@ -4,6 +4,6 @@ import com.growthook.aos.data.entity.User
 
 interface UserRepository {
 
-    suspend fun setUserInfo(userName: String)
+    suspend fun setUserInfo(userName: String, memberId:Int)
     suspend fun getUserInfo(): User
 }

--- a/app/src/main/java/com/growthook/aos/domain/usecase/DeleteSeedUseCase.kt
+++ b/app/src/main/java/com/growthook/aos/domain/usecase/DeleteSeedUseCase.kt
@@ -1,0 +1,9 @@
+package com.growthook.aos.domain.usecase
+
+import com.growthook.aos.domain.repository.SeedRepository
+import javax.inject.Inject
+
+class DeleteSeedUseCase @Inject constructor(private val repository: SeedRepository) {
+
+    suspend operator fun invoke(seedId: Int) = repository.deleteSeed(seedId)
+}

--- a/app/src/main/java/com/growthook/aos/domain/usecase/GetCavesUseCase.kt
+++ b/app/src/main/java/com/growthook/aos/domain/usecase/GetCavesUseCase.kt
@@ -1,4 +1,4 @@
-package com.growthook.aos.domain.usecase.home
+package com.growthook.aos.domain.usecase
 
 import com.growthook.aos.domain.repository.CaveRepository
 import javax.inject.Inject

--- a/app/src/main/java/com/growthook/aos/domain/usecase/MoveSeedUseCase.kt
+++ b/app/src/main/java/com/growthook/aos/domain/usecase/MoveSeedUseCase.kt
@@ -1,0 +1,9 @@
+package com.growthook.aos.domain.usecase
+
+import com.growthook.aos.domain.repository.SeedRepository
+import javax.inject.Inject
+
+class MoveSeedUseCase @Inject constructor(private val repository: SeedRepository) {
+    suspend operator fun invoke(seedId: Int, toMoveCaveId: Int) =
+        repository.moveSeed(seedId, toMoveCaveId)
+}

--- a/app/src/main/java/com/growthook/aos/domain/usecase/cavedetail/DeleteCaveUseCase.kt
+++ b/app/src/main/java/com/growthook/aos/domain/usecase/cavedetail/DeleteCaveUseCase.kt
@@ -1,0 +1,9 @@
+package com.growthook.aos.domain.usecase.cavedetail
+
+import com.growthook.aos.domain.repository.CaveRepository
+import javax.inject.Inject
+
+class DeleteCaveUseCase @Inject constructor(private val repository: CaveRepository) {
+
+    suspend operator fun invoke(caveId: Int) = repository.deleteCave(caveId)
+}

--- a/app/src/main/java/com/growthook/aos/domain/usecase/cavedetail/GetCaveDetailUseCase.kt
+++ b/app/src/main/java/com/growthook/aos/domain/usecase/cavedetail/GetCaveDetailUseCase.kt
@@ -1,0 +1,9 @@
+package com.growthook.aos.domain.usecase.cavedetail
+
+import com.growthook.aos.domain.repository.CaveRepository
+import javax.inject.Inject
+
+class GetCaveDetailUseCase @Inject constructor(private val repository: CaveRepository) {
+    suspend operator fun invoke(memberId: Int, caveId: Int) =
+        repository.getCaveDetail(memberId, caveId)
+}

--- a/app/src/main/java/com/growthook/aos/domain/usecase/cavedetail/ModifyCaveUseCase.kt
+++ b/app/src/main/java/com/growthook/aos/domain/usecase/cavedetail/ModifyCaveUseCase.kt
@@ -1,0 +1,9 @@
+package com.growthook.aos.domain.usecase.cavedetail
+
+import com.growthook.aos.domain.repository.CaveRepository
+import javax.inject.Inject
+
+class ModifyCaveUseCase @Inject constructor(private val repository: CaveRepository) {
+    suspend operator fun invoke(caveId: Int, name: String, introduction: String) =
+        repository.modifyCave(caveId, name, introduction)
+}

--- a/app/src/main/java/com/growthook/aos/domain/usecase/home/GetCavesUseCase.kt
+++ b/app/src/main/java/com/growthook/aos/domain/usecase/home/GetCavesUseCase.kt
@@ -1,0 +1,8 @@
+package com.growthook.aos.domain.usecase.home
+
+import com.growthook.aos.domain.repository.CaveRepository
+import javax.inject.Inject
+
+class GetCavesUseCase @Inject constructor(private val repository: CaveRepository) {
+    suspend operator fun invoke(memberId: Int) = repository.getCaves(memberId)
+}

--- a/app/src/main/java/com/growthook/aos/domain/usecase/local/PostUserUseCase.kt
+++ b/app/src/main/java/com/growthook/aos/domain/usecase/local/PostUserUseCase.kt
@@ -4,5 +4,6 @@ import com.growthook.aos.domain.repository.UserRepository
 import javax.inject.Inject
 
 class PostUserUseCase @Inject constructor(private val repository: UserRepository) {
-    suspend operator fun invoke(userName: String) = repository.setUserInfo(userName)
+    suspend operator fun invoke(userName: String, memberId: Int) =
+        repository.setUserInfo(userName, memberId)
 }

--- a/app/src/main/java/com/growthook/aos/presentation/cavecreate/CreateNewCaveActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavecreate/CreateNewCaveActivity.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.view.MotionEvent
 import android.widget.Toast
 import androidx.activity.viewModels
-import com.growthook.aos.presentation.cavecreate.model.NewCaveIntent
+import com.growthook.aos.presentation.model.NewCaveIntent
 import com.growthook.aos.databinding.ActivityCreateNewCaveBinding
 import com.growthook.aos.util.base.BaseActivity
 import com.growthook.aos.util.base.BaseAlertDialog

--- a/app/src/main/java/com/growthook/aos/presentation/cavecreate/SeeNewCaveActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavecreate/SeeNewCaveActivity.kt
@@ -2,7 +2,7 @@ package com.growthook.aos.presentation.cavecreate
 
 import android.os.Bundle
 import androidx.activity.viewModels
-import com.growthook.aos.presentation.cavecreate.model.NewCaveIntent
+import com.growthook.aos.presentation.model.NewCaveIntent
 import com.growthook.aos.databinding.ActivitySeeNewCaveBinding
 import com.growthook.aos.presentation.cavecreate.CreateNewCaveActivity.Companion.NEW_STORAGE
 import com.growthook.aos.util.base.BaseActivity

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailActivity.kt
@@ -29,6 +29,8 @@ class CaveDetailActivity : BaseActivity<ActivityCaveDetailBinding>({
 
     private var _insightAdapter: HomeInsightAdapter? = null
     private lateinit var selectMenuBottomSheet: CaveDetailSelectMenuBottomSheet
+    private lateinit var modifySelectBottomSheet: CaveModifySelectBottomSheet
+
     private val insightAdapter
         get() = requireNotNull(_insightAdapter) { "adapter is null" }
 
@@ -39,8 +41,10 @@ class CaveDetailActivity : BaseActivity<ActivityCaveDetailBinding>({
 
         clickLock()
         selectMenuBottomSheet = CaveDetailSelectMenuBottomSheet()
+        modifySelectBottomSheet = CaveModifySelectBottomSheet()
 
         val caveId = intent.getIntExtra("caveId", 0)
+        viewModel.caveId.value = caveId
         viewModel.getInsights(caveId)
         setInsightAdapter()
         setNickName()
@@ -49,7 +53,6 @@ class CaveDetailActivity : BaseActivity<ActivityCaveDetailBinding>({
         clickBackNavi()
         clickMainMenu()
     }
-
 
     private fun setInsightAdapter() {
         _insightAdapter = HomeInsightAdapter(::selectedItem, ::clickedScrap)
@@ -188,8 +191,7 @@ class CaveDetailActivity : BaseActivity<ActivityCaveDetailBinding>({
 
     private fun clickMainMenu() {
         binding.ibCaveDetailMainmenu.setOnClickListener {
-            val bottomSheet = CaveModifySelectBottomSheet()
-            bottomSheet.show(supportFragmentManager, "show")
+            modifySelectBottomSheet.show(supportFragmentManager, "show2")
         }
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.selection.SelectionPredicates
 import androidx.recyclerview.selection.SelectionTracker
 import androidx.recyclerview.selection.StableIdKeyProvider
@@ -18,6 +19,7 @@ import com.growthook.aos.util.EmptyDataObserver
 import com.growthook.aos.util.base.BaseActivity
 import com.growthook.aos.util.base.BaseAlertDialog
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -46,12 +48,26 @@ class CaveDetailActivity : BaseActivity<ActivityCaveDetailBinding>({
         val caveId = intent.getIntExtra("caveId", 0)
         viewModel.caveId.value = caveId
         viewModel.getInsights(caveId)
+        setCaveDetail()
         setInsightAdapter()
         setNickName()
         clickScrap(caveId)
 
         clickBackNavi()
         clickMainMenu()
+    }
+
+    private fun setCaveDetail() {
+        lifecycleScope.launch {
+            viewModel.caveId.collect {
+                viewModel.getCaveDetail(it)
+            }
+        }
+
+        viewModel.caveDetail.observe(this) { caveDetail ->
+            binding.tvCaveDetailCaveName.text = caveDetail.caveName
+            binding.tvCaveDetailCaveDesc.text = caveDetail.introduction
+        }
     }
 
     private fun setInsightAdapter() {

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailDeleteAlert.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailDeleteAlert.kt
@@ -1,0 +1,90 @@
+package com.growthook.aos.presentation.cavedetail
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.growthook.aos.databinding.DialogLeftIntendedBinding
+import com.growthook.aos.presentation.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@AndroidEntryPoint
+class CaveDetailDeleteAlert : DialogFragment() {
+
+    private var _binding: DialogLeftIntendedBinding? = null
+    private val binding: DialogLeftIntendedBinding
+        get() = requireNotNull(_binding) { "binding is null" }
+
+    private val viewModel: CaveDetailViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        _binding = DialogLeftIntendedBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setText()
+        clickLeftBtn()
+        clickRightBtn()
+    }
+
+    private fun setText() {
+        binding.tvLeftIntendedTitle.text = "정말로 삭제할까요?"
+        binding.tvLeftIntendedDesc.text = "삭제한 보관함은 다시 복구할 수 없으니\n" +
+            "신중하게 결정해 주세요!"
+        binding.tvLeftIntendedLeft.text = "유지하기"
+        binding.tvLeftIntendedRight.text = "삭제하기"
+    }
+
+    private fun clickLeftBtn() {
+        binding.tvLeftIntendedLeft.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    private fun clickRightBtn() {
+        binding.tvLeftIntendedRight.setOnClickListener {
+            deleteCave()
+            afterDeleteSuccess()
+        }
+    }
+
+    private fun deleteCave() {
+        lifecycleScope.launch {
+            viewModel.caveId.collect {
+                if (it != 0) {
+                    viewModel.deleteCave(it)
+                }
+            }
+        }
+    }
+
+    private fun afterDeleteSuccess() {
+        viewModel.isDelete.observe(viewLifecycleOwner) { isDelete ->
+            if (isDelete) {
+                Toast.makeText(requireContext(), "동굴이 삭제되었어요", Toast.LENGTH_SHORT).show()
+                val intent = Intent(requireActivity(), MainActivity::class.java)
+                startActivity(intent)
+                dismiss()
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        _binding = null
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailSelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailSelectMenuBottomSheet.kt
@@ -64,13 +64,8 @@ class CaveDetailSelectMenuBottomSheet() :
                     isRemainThookVisility = false,
                     isTipVisility = false,
                     negativeAction = {
-                        viewModel.deleteCave(6)
-                        viewModel.isDelete.observe(viewLifecycleOwner) { isDelete ->
-                            if (isDelete) {
-                                Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT)
-                                    .show()
-                            }
-                        }
+                        Toast.makeText(requireContext(), "씨앗이 삭제되었어요", Toast.LENGTH_SHORT)
+                            .show()
                     },
                     positiveAction = {},
                 ).show(parentFragmentManager, InsightMenuBottomsheet.DELETE_DIALOG)

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailSelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailSelectMenuBottomSheet.kt
@@ -39,7 +39,8 @@ class CaveDetailSelectMenuBottomSheet() :
     private fun clickMoveBtn() {
         binding.btnHomeSelectMove.setOnClickListener {
             CaveSelect.Builder().build(
-                viewModel.longClickInsight.value?.insightId ?: 0,
+                CaveSelect.CaveSelectType.YES_API,
+                viewModel.longClickInsight.value?.insightId ?: 1,
             ).show(parentFragmentManager, "select")
         }
     }

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailSelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailSelectMenuBottomSheet.kt
@@ -64,7 +64,13 @@ class CaveDetailSelectMenuBottomSheet() :
                     isRemainThookVisility = false,
                     isTipVisility = false,
                     negativeAction = {
-                        Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT).show()
+                        viewModel.deleteCave(6)
+                        viewModel.isDelete.observe(viewLifecycleOwner) { isDelete ->
+                            if (isDelete) {
+                                Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT)
+                                    .show()
+                            }
+                        }
                     },
                     positiveAction = {},
                 ).show(parentFragmentManager, InsightMenuBottomsheet.DELETE_DIALOG)

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailSelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailSelectMenuBottomSheet.kt
@@ -38,13 +38,9 @@ class CaveDetailSelectMenuBottomSheet() :
 
     private fun clickMoveBtn() {
         binding.btnHomeSelectMove.setOnClickListener {
-            CaveSelect.Builder().build {
-                Toast.makeText(
-                    requireContext(),
-                    "${it?.name}에 ${viewModel.longClickInsight.value}를 옮깁니다",
-                    Toast.LENGTH_SHORT,
-                ).show()
-            }.show(parentFragmentManager, "select")
+            CaveSelect.Builder().build(
+                viewModel.longClickInsight.value?.insightId ?: 0,
+            ).show(parentFragmentManager, "select")
         }
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.growthook.aos.domain.entity.Insight
+import com.growthook.aos.domain.usecase.cavedetail.DeleteCaveUseCase
 import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -13,6 +14,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CaveDetailViewModel @Inject constructor(
     private val getUserUseCase: GetUserUseCase,
+    private val deleteCaveUseCase: DeleteCaveUseCase,
 ) : ViewModel() {
     private val _insights = MutableLiveData<List<Insight>>()
     val insights: LiveData<List<Insight>> = _insights
@@ -21,6 +23,9 @@ class CaveDetailViewModel @Inject constructor(
 
     private val _nickName = MutableLiveData<String>()
     val nickname: LiveData<String> = _nickName
+
+    private val _isDelete = MutableLiveData<Boolean>()
+    val isDelete: LiveData<Boolean> = _isDelete
 
     val isMenuDismissed = MutableLiveData<Boolean>()
 
@@ -129,5 +134,15 @@ class CaveDetailViewModel @Inject constructor(
 
     fun getScrapedInsight() {
         _insights.value = scrapedInsight.value
+    }
+
+    fun deleteCave(caveId: Int) {
+        viewModelScope.launch {
+            deleteCaveUseCase.invoke(caveId).onSuccess {
+                _isDelete.value = true
+            }.onFailure {
+                _isDelete.value = false
+            }
+        }
     }
 }

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailViewModel.kt
@@ -4,18 +4,22 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.growthook.aos.domain.entity.CaveDetail
 import com.growthook.aos.domain.entity.Insight
 import com.growthook.aos.domain.usecase.cavedetail.DeleteCaveUseCase
+import com.growthook.aos.domain.usecase.cavedetail.GetCaveDetailUseCase
 import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class CaveDetailViewModel @Inject constructor(
     private val getUserUseCase: GetUserUseCase,
     private val deleteCaveUseCase: DeleteCaveUseCase,
+    private val getCaveDetailUseCase: GetCaveDetailUseCase,
 ) : ViewModel() {
     private val _insights = MutableLiveData<List<Insight>>()
     val insights: LiveData<List<Insight>> = _insights
@@ -27,6 +31,9 @@ class CaveDetailViewModel @Inject constructor(
 
     private val _isDelete = MutableLiveData<Boolean>()
     val isDelete: LiveData<Boolean> = _isDelete
+
+    private val _caveDetail = MutableLiveData<CaveDetail>()
+    val caveDetail: LiveData<CaveDetail> = _caveDetail
 
     val caveId = MutableStateFlow<Int>(0)
 
@@ -145,6 +152,16 @@ class CaveDetailViewModel @Inject constructor(
                 _isDelete.value = true
             }.onFailure {
                 _isDelete.value = false
+            }
+        }
+    }
+
+    fun getCaveDetail(caveId: Int) {
+        viewModelScope.launch {
+            getCaveDetailUseCase(getUserUseCase.invoke()?.memberId ?: 0, caveId).onSuccess {
+                _caveDetail.value = it
+            }.onFailure {
+                Timber.e(it.message)
             }
         }
     }

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.growthook.aos.domain.entity.Insight
 import com.growthook.aos.domain.usecase.cavedetail.DeleteCaveUseCase
 import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,6 +27,8 @@ class CaveDetailViewModel @Inject constructor(
 
     private val _isDelete = MutableLiveData<Boolean>()
     val isDelete: LiveData<Boolean> = _isDelete
+
+    val caveId = MutableStateFlow<Int>(0)
 
     val isMenuDismissed = MutableLiveData<Boolean>()
 

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveModifySelectBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveModifySelectBottomSheet.kt
@@ -5,15 +5,19 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
 import com.growthook.aos.R
 import com.growthook.aos.databinding.FragmentCaveModifySelectBottomsheetBinding
 import com.growthook.aos.presentation.cavedetail.cavemodify.CaveDetailModifyActivity
+import com.growthook.aos.presentation.model.CaveModifyIntent
 import com.growthook.aos.util.base.BaseBottomSheetFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class CaveModifySelectBottomSheet :
     BaseBottomSheetFragment<FragmentCaveModifySelectBottomsheetBinding>(R.layout.fragment_cave_modify_select_bottomsheet) {
+
+    private val viewModel by activityViewModels<CaveDetailViewModel>()
     override fun getFragmentBinding(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -36,7 +40,14 @@ class CaveModifySelectBottomSheet :
     private fun clickModify() {
         binding.btnCaveDetailModify.setOnClickListener {
             val intent = Intent(requireActivity(), CaveDetailModifyActivity::class.java)
-            intent.putExtra("caveName", "동굴 이름이름")
+            intent.putExtra(
+                "caveModify",
+                CaveModifyIntent(
+                    viewModel.caveId.value,
+                    viewModel.caveDetail.value?.caveName ?: "",
+                    viewModel.caveDetail.value?.introduction ?: "",
+                ),
+            )
             startActivity(intent)
             dismiss()
         }

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveModifySelectBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveModifySelectBottomSheet.kt
@@ -5,15 +5,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import com.growthook.aos.R
 import com.growthook.aos.databinding.FragmentCaveModifySelectBottomsheetBinding
-import com.growthook.aos.presentation.MainActivity
 import com.growthook.aos.presentation.cavedetail.cavemodify.CaveDetailModifyActivity
-import com.growthook.aos.presentation.insight.noactionplan.InsightMenuBottomsheet
-import com.growthook.aos.util.base.BaseAlertDialog
 import com.growthook.aos.util.base.BaseBottomSheetFragment
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class CaveModifySelectBottomSheet :
     BaseBottomSheetFragment<FragmentCaveModifySelectBottomsheetBinding>(R.layout.fragment_cave_modify_select_bottomsheet) {
     override fun getFragmentBinding(
@@ -31,27 +29,7 @@ class CaveModifySelectBottomSheet :
     private fun clickDelete() {
         binding.btnCaveDetailDelete.setOnClickListener {
             dismiss()
-            BaseAlertDialog.Builder()
-                .setCancelable(false)
-                .build(
-                    type = BaseAlertDialog.DialogType.LEFT_INTENDED,
-                    title = "정말로 삭제할까요?",
-                    description = "삭제한 보관함은 다시 복구할 수 없으니\n신중하게 결정해 주세요!",
-                    positiveText = "유지하기",
-                    negativeText = "삭제하기",
-                    tipText = "",
-                    isBackgroundImageVisility = false,
-                    isDescriptionVisility = true,
-                    isRemainThookVisility = false,
-                    isTipVisility = false,
-                    negativeAction = {
-                        Toast.makeText(context, "동굴이 삭제되었어요", Toast.LENGTH_SHORT).show()
-                        val intent = Intent(requireActivity(), MainActivity::class.java)
-                        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
-                        startActivity(intent)
-                    },
-                    positiveAction = {},
-                ).show(parentFragmentManager, InsightMenuBottomsheet.DELETE_DIALOG)
+            CaveDetailDeleteAlert().show(parentFragmentManager, "modify")
         }
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/cavemodify/CaveDetailModifyActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/cavemodify/CaveDetailModifyActivity.kt
@@ -6,8 +6,10 @@ import android.view.MotionEvent
 import androidx.activity.viewModels
 import com.growthook.aos.databinding.ActivityCaveDetailModifyBinding
 import com.growthook.aos.presentation.cavedetail.CaveDetailActivity
+import com.growthook.aos.presentation.model.CaveModifyIntent
 import com.growthook.aos.util.base.BaseActivity
 import com.growthook.aos.util.extension.CommonTextWatcher
+import com.growthook.aos.util.extension.getParcelable
 import com.growthook.aos.util.extension.hideKeyboard
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -18,11 +20,17 @@ class CaveDetailModifyActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding.edtCaveModifyName.setText(intent.getStringExtra("caveName"))
+        setText()
         observeIsModified()
         canClickFinishBtn()
         clickBackNavi()
         clickFinishBtn()
+    }
+
+    private fun setText() {
+        val caveModifyIntent = intent.getParcelable("caveModify", CaveModifyIntent::class.java)
+        binding.edtCaveModifyName.setText(caveModifyIntent?.name)
+        binding.edtCaveModifyDesc.setText(caveModifyIntent?.introduction)
     }
 
     private fun observeIsModified() {

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/cavemodify/CaveDetailModifyActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/cavemodify/CaveDetailModifyActivity.kt
@@ -20,15 +20,17 @@ class CaveDetailModifyActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setText()
+
+        val caveModifyIntent = intent.getParcelable("caveModify", CaveModifyIntent::class.java)
+
+        setText(caveModifyIntent)
         observeIsModified()
         canClickFinishBtn()
         clickBackNavi()
-        clickFinishBtn()
+        clickFinishBtn(caveModifyIntent)
     }
 
-    private fun setText() {
-        val caveModifyIntent = intent.getParcelable("caveModify", CaveModifyIntent::class.java)
+    private fun setText(caveModifyIntent: CaveModifyIntent?) {
         binding.edtCaveModifyName.setText(caveModifyIntent?.name)
         binding.edtCaveModifyDesc.setText(caveModifyIntent?.introduction)
     }
@@ -56,11 +58,16 @@ class CaveDetailModifyActivity :
         }
     }
 
-    private fun clickFinishBtn() {
+    private fun clickFinishBtn(caveModifyIntent: CaveModifyIntent?) {
         binding.btnCaveModify.setOnClickListener {
-            val intent = Intent(this, CaveDetailActivity::class.java)
-            startActivity(intent)
-            finish()
+            caveModifyIntent?.let {
+                viewModel.modifyCave(it.caveId, it.name, it.introduction)
+                viewModel.isModifySuccess.observe(this) {
+                    val intent = Intent(this, CaveDetailActivity::class.java)
+                    startActivity(intent)
+                    finish()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/cavemodify/CaveDetailModifyViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/cavemodify/CaveDetailModifyViewModel.kt
@@ -3,17 +3,38 @@ package com.growthook.aos.presentation.cavedetail.cavemodify
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.growthook.aos.domain.usecase.cavedetail.ModifyCaveUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
-class CaveDetailModifyViewModel @Inject constructor() : ViewModel() {
+class CaveDetailModifyViewModel @Inject constructor(
+    private val modifyCaveUseCase: ModifyCaveUseCase,
+) : ViewModel() {
 
     private val _isCaveModified = MutableLiveData<Boolean>(false)
     val isCaveModified: LiveData<Boolean>
         get() = _isCaveModified
 
+    private val _isModifySuccess = MutableLiveData<Boolean>()
+    val isModifySuccess: LiveData<Boolean>
+        get() = _isModifySuccess
+
     fun setIsModified(modify: Boolean) {
         _isCaveModified.value = modify
+    }
+
+    fun modifyCave(caveId: Int, name: String, introduction: String) {
+        viewModelScope.launch {
+            modifyCaveUseCase(caveId, name, introduction).onSuccess {
+                _isModifySuccess.value = true
+            }.onFailure {
+                _isModifySuccess.value = false
+                Timber.e(it.message)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/growthook/aos/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/HomeFragment.kt
@@ -63,6 +63,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         activity = requireActivity() as MainActivity
 
         clickAddCave()
+        getCaves()
     }
 
     private fun clickAddCave() {
@@ -77,6 +78,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         viewModel.nickname.observe(viewLifecycleOwner) { nickName ->
             binding.tvHomeAppbarTitle.text = "${nickName}님의 동굴 속"
         }
+    }
+
+    private fun getCaves(){
+        viewModel.getCaves()
     }
 
     private fun setInsightAdapter() {

--- a/app/src/main/java/com/growthook/aos/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/HomeFragment.kt
@@ -73,6 +73,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     }
 
     private fun setTitleText() {
+        viewModel.setNickName()
         viewModel.nickname.observe(viewLifecycleOwner) { nickName ->
             binding.tvHomeAppbarTitle.text = "${nickName}님의 동굴 속"
         }

--- a/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.growthook.aos.domain.entity.Cave
 import com.growthook.aos.domain.entity.Insight
+import com.growthook.aos.domain.usecase.cavedetail.DeleteCaveUseCase
 import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -15,6 +16,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val getUserUseCase: GetUserUseCase,
+    private val deleteCaveUseCase: DeleteCaveUseCase
 ) : ViewModel() {
 
     private val _nickName = MutableLiveData<String>()
@@ -28,6 +30,9 @@ class HomeViewModel @Inject constructor(
 
     private val _caves = MutableLiveData<List<Cave>>()
     val caves: LiveData<List<Cave>> = _caves
+
+    private val _isDelete = MutableLiveData<Boolean>()
+    val isDelete: LiveData<Boolean> = _isDelete
 
     val isMenuDismissed = MutableLiveData<Boolean>()
 
@@ -158,5 +163,15 @@ class HomeViewModel @Inject constructor(
 
     fun changeScrap(isScrap: Boolean) {
         // TODO 스크랩 api 구현
+    }
+
+    fun deleteCave(caveId: Int) {
+        viewModelScope.launch {
+            deleteCaveUseCase.invoke(caveId).onSuccess {
+                _isDelete.value = true
+            }.onFailure {
+                _isDelete.value = false
+            }
+        }
     }
 }

--- a/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.growthook.aos.domain.entity.Cave
 import com.growthook.aos.domain.entity.Insight
 import com.growthook.aos.domain.usecase.DeleteSeedUseCase
-import com.growthook.aos.domain.usecase.cavedetail.DeleteCaveUseCase
 import com.growthook.aos.domain.usecase.GetCavesUseCase
 import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -146,9 +145,9 @@ class HomeViewModel @Inject constructor(
         Timber.d("getScrapedInsight ${_insights.value?.size}")
     }
 
-    fun getCaves(memberId: Int) {
+    fun getCaves() {
         viewModelScope.launch {
-            getCavesUseCase(memberId).onSuccess { caves ->
+            getCavesUseCase(getUserUseCase.invoke().memberId ?: 0).onSuccess { caves ->
                 _caves.value = caves
             }
         }
@@ -157,8 +156,6 @@ class HomeViewModel @Inject constructor(
     fun setNickName() {
         viewModelScope.launch {
             _nickName.value = getUserUseCase.invoke().name ?: ""
-            getCaves(getUserUseCase.invoke().memberId ?: 0)
-            Timber.d("home viewmodel 유저 닉네임: ${nickname.value}")
         }
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
@@ -45,6 +45,8 @@ class HomeViewModel @Inject constructor(
 
             getAlertCount()
             getInsights()
+            setNickName()
+            getCaves()
         }
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
@@ -165,7 +165,7 @@ class HomeViewModel @Inject constructor(
         // TODO 스크랩 api 구현
     }
 
-    fun deleteCave(caveId: Int) {
+    fun deleteSeed(caveId: Int) {
         viewModelScope.launch {
             deleteSeedUseCase.invoke(caveId).onSuccess {
                 _isDelete.value = true

--- a/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/HomeViewModel.kt
@@ -6,8 +6,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.growthook.aos.domain.entity.Cave
 import com.growthook.aos.domain.entity.Insight
+import com.growthook.aos.domain.usecase.DeleteSeedUseCase
 import com.growthook.aos.domain.usecase.cavedetail.DeleteCaveUseCase
-import com.growthook.aos.domain.usecase.home.GetCavesUseCase
+import com.growthook.aos.domain.usecase.GetCavesUseCase
 import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -17,7 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val getUserUseCase: GetUserUseCase,
-    private val deleteCaveUseCase: DeleteCaveUseCase,
+    private val deleteSeedUseCase: DeleteSeedUseCase,
     private val getCavesUseCase: GetCavesUseCase,
 ) : ViewModel() {
 
@@ -167,7 +168,7 @@ class HomeViewModel @Inject constructor(
 
     fun deleteCave(caveId: Int) {
         viewModelScope.launch {
-            deleteCaveUseCase.invoke(caveId).onSuccess {
+            deleteSeedUseCase.invoke(caveId).onSuccess {
                 _isDelete.value = true
             }.onFailure {
                 _isDelete.value = false

--- a/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
@@ -36,13 +36,9 @@ class SelectMenuBottomSheet() :
 
     private fun clickMoveBtn() {
         binding.btnHomeSelectMove.setOnClickListener {
-            CaveSelect.Builder().build {
-                Toast.makeText(
-                    requireContext(),
-                    "${it?.name}에 ${viewModel.longClickInsight.value?.insightId}를 옮깁니다",
-                    Toast.LENGTH_SHORT,
-                ).show()
-            }.show(parentFragmentManager, "select")
+            CaveSelect.Builder().build(
+                viewModel.longClickInsight.value?.insightId ?: 1,
+            ).show(parentFragmentManager, "select")
         }
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
@@ -14,7 +14,6 @@ import com.growthook.aos.presentation.insight.noactionplan.InsightMenuBottomshee
 import com.growthook.aos.util.base.BaseAlertDialog
 import com.growthook.aos.util.base.BaseBottomSheetFragment
 import com.growthook.aos.util.selectcave.CaveSelect
-import timber.log.Timber
 
 class SelectMenuBottomSheet() :
     BaseBottomSheetFragment<FragmentSelectMenuBottomsheetBinding>(R.layout.fragment_select_menu_bottomsheet) {
@@ -63,7 +62,10 @@ class SelectMenuBottomSheet() :
                     isRemainThookVisility = false,
                     isTipVisility = false,
                     negativeAction = {
-                        Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT).show()
+                        viewModel.deleteCave(5)
+                        viewModel.isDelete.observe(viewLifecycleOwner) {
+                            Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT).show()
+                        }
                     },
                     positiveAction = {},
                 ).show(parentFragmentManager, InsightMenuBottomsheet.DELETE_DIALOG)

--- a/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
@@ -58,7 +58,7 @@ class SelectMenuBottomSheet() :
                     isRemainThookVisility = false,
                     isTipVisility = false,
                     negativeAction = {
-                        viewModel.deleteCave(viewModel.longClickInsight.value?.insightId ?: 0)
+                        viewModel.deleteSeed(viewModel.longClickInsight.value?.insightId ?: 0)
                         viewModel.isDelete.observe(viewLifecycleOwner) { isDelete ->
                             if (isDelete) {
                                 Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
@@ -14,6 +14,7 @@ import com.growthook.aos.presentation.insight.noactionplan.InsightMenuBottomshee
 import com.growthook.aos.util.base.BaseAlertDialog
 import com.growthook.aos.util.base.BaseBottomSheetFragment
 import com.growthook.aos.util.selectcave.CaveSelect
+import timber.log.Timber
 
 class SelectMenuBottomSheet() :
     BaseBottomSheetFragment<FragmentSelectMenuBottomsheetBinding>(R.layout.fragment_select_menu_bottomsheet) {
@@ -37,6 +38,7 @@ class SelectMenuBottomSheet() :
     private fun clickMoveBtn() {
         binding.btnHomeSelectMove.setOnClickListener {
             CaveSelect.Builder().build(
+                CaveSelect.CaveSelectType.YES_API,
                 viewModel.longClickInsight.value?.insightId ?: 1,
             ).show(parentFragmentManager, "select")
         }

--- a/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
@@ -39,7 +39,7 @@ class SelectMenuBottomSheet() :
             CaveSelect.Builder().build {
                 Toast.makeText(
                     requireContext(),
-                    "${it?.name}에 ${viewModel.longClickInsight.value}를 옮깁니다",
+                    "${it?.name}에 ${viewModel.longClickInsight.value?.insightId}를 옮깁니다",
                     Toast.LENGTH_SHORT,
                 ).show()
             }.show(parentFragmentManager, "select")
@@ -62,7 +62,12 @@ class SelectMenuBottomSheet() :
                     isRemainThookVisility = false,
                     isTipVisility = false,
                     negativeAction = {
-                        Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT).show()
+                        viewModel.deleteCave(viewModel.longClickInsight.value?.insightId ?: 0)
+                        viewModel.isDelete.observe(viewLifecycleOwner) { isDelete ->
+                            if (isDelete) {
+                                Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT).show()
+                            }
+                        }
                     },
                     positiveAction = {},
                 ).show(parentFragmentManager, InsightMenuBottomsheet.DELETE_DIALOG)

--- a/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/SelectMenuBottomSheet.kt
@@ -62,10 +62,7 @@ class SelectMenuBottomSheet() :
                     isRemainThookVisility = false,
                     isTipVisility = false,
                     negativeAction = {
-                        viewModel.deleteCave(5)
-                        viewModel.isDelete.observe(viewLifecycleOwner) {
-                            Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT).show()
-                        }
+                        Toast.makeText(context, "씨앗이 삭제되었어요", Toast.LENGTH_SHORT).show()
                     },
                     positiveAction = {},
                 ).show(parentFragmentManager, InsightMenuBottomsheet.DELETE_DIALOG)

--- a/app/src/main/java/com/growthook/aos/presentation/model/CaveModifyIntent.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/model/CaveModifyIntent.kt
@@ -1,0 +1,11 @@
+package com.growthook.aos.presentation.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class CaveModifyIntent(
+    val caveId: Int,
+    val name: String,
+    val introduction: String,
+) : Parcelable

--- a/app/src/main/java/com/growthook/aos/presentation/model/NewCaveIntent.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/model/NewCaveIntent.kt
@@ -1,4 +1,4 @@
-package com.growthook.aos.presentation.cavecreate.model
+package com.growthook.aos.presentation.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize

--- a/app/src/main/java/com/growthook/aos/presentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/mypage/MyPageViewModel.kt
@@ -29,7 +29,7 @@ class MyPageViewModel @Inject constructor(
             Timber.d("로그아웃 성공 여부 $it")
             _isLogoutSuccess.value = it
             viewModelScope.launch {
-                postUserUseCase.invoke("")
+                postUserUseCase.invoke("", 0)
             }
         }.handleResult(error)
     }

--- a/app/src/main/java/com/growthook/aos/presentation/mypage/detailinfo/DetailMyPageViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/mypage/detailinfo/DetailMyPageViewModel.kt
@@ -28,7 +28,7 @@ class DetailMyPageViewModel @Inject constructor(
         KakaoLogoutCallback {
             _isKakaoDeleteAccount.value = true
             viewModelScope.launch {
-                postUserUseCase.invoke("")
+                postUserUseCase.invoke("", 0)
             }
         }.handleResult(error)
     }

--- a/app/src/main/java/com/growthook/aos/presentation/onboarding/LoginViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/onboarding/LoginViewModel.kt
@@ -39,7 +39,7 @@ class LoginViewModel @Inject constructor(
     val kakaoUserCallback: (User?, Throwable?) -> Unit = { user, error ->
         KakaoUserCallback { userName ->
             viewModelScope.launch {
-                postUserUseCase.invoke(userName)
+                postUserUseCase.invoke(userName, 1)
                 Timber.d("유저 닉네임: ${getUserUseCase.invoke().name}")
             }
         }.handleResult(user, error)

--- a/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelect.kt
+++ b/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelect.kt
@@ -6,13 +6,12 @@ import android.view.View
 import android.view.ViewGroup
 import com.growthook.aos.R
 import com.growthook.aos.databinding.FragmentCaveSelectBottomsheetBinding
-import com.growthook.aos.domain.entity.Cave
 import com.growthook.aos.util.base.BaseBottomSheetFragment
 
 abstract class CaveSelect :
     BaseBottomSheetFragment<FragmentCaveSelectBottomsheetBinding>(R.layout.fragment_cave_select_bottomsheet) {
 
-    protected lateinit var clickBtnAction: (Cave?) -> Unit
+    protected var toMoveSeedId: Int = 0
 
     override fun getFragmentBinding(
         inflater: LayoutInflater,
@@ -20,17 +19,17 @@ abstract class CaveSelect :
     ): FragmentCaveSelectBottomsheetBinding =
         FragmentCaveSelectBottomsheetBinding.inflate(inflater, container, false)
 
-    abstract fun setClickAction(action: (Cave?) -> Unit)
+    abstract fun moveSeed()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setClickAction { clickBtnAction }
+        moveSeed()
     }
 
     class Builder {
-        fun build(clickAction: (Cave?) -> Unit): CaveSelect {
+        fun build(toMoveSeedId: Int): CaveSelect {
             return CaveSelectBottomSheet().apply {
-                this.clickBtnAction = clickAction
+                this.toMoveSeedId = toMoveSeedId
             }
         }
     }

--- a/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelect.kt
+++ b/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelect.kt
@@ -1,17 +1,17 @@
 package com.growthook.aos.util.selectcave
 
-import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import com.growthook.aos.R
 import com.growthook.aos.databinding.FragmentCaveSelectBottomsheetBinding
+import com.growthook.aos.domain.entity.Cave
 import com.growthook.aos.util.base.BaseBottomSheetFragment
 
 abstract class CaveSelect :
     BaseBottomSheetFragment<FragmentCaveSelectBottomsheetBinding>(R.layout.fragment_cave_select_bottomsheet) {
 
     protected var toMoveSeedId: Int = 0
+    protected lateinit var clickBtnAction: (Cave) -> Unit
 
     override fun getFragmentBinding(
         inflater: LayoutInflater,
@@ -19,18 +19,27 @@ abstract class CaveSelect :
     ): FragmentCaveSelectBottomsheetBinding =
         FragmentCaveSelectBottomsheetBinding.inflate(inflater, container, false)
 
-    abstract fun moveSeed()
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        moveSeed()
-    }
-
     class Builder {
-        fun build(toMoveSeedId: Int): CaveSelect {
-            return CaveSelectBottomSheet().apply {
+        fun build(
+            type: CaveSelectType,
+            toMoveSeedId: Int,
+            clickBtnAction: (Cave) -> Unit = {},
+        ): CaveSelect {
+            return type.getInstance().apply {
                 this.toMoveSeedId = toMoveSeedId
+                this.clickBtnAction = clickBtnAction
             }
         }
+    }
+
+    enum class CaveSelectType {
+        YES_API {
+            override fun getInstance(): CaveSelect = YesApiCaveSelectBottomSheet()
+        },
+        NO_API {
+            override fun getInstance(): CaveSelect = NoApiCaveSelectBottomSheet()
+        }, ;
+
+        abstract fun getInstance(): CaveSelect
     }
 }

--- a/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelectBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelectBottomSheet.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.selection.SelectionPredicates
@@ -11,7 +12,6 @@ import androidx.recyclerview.selection.SelectionTracker
 import androidx.recyclerview.selection.StableIdKeyProvider
 import androidx.recyclerview.selection.StorageStrategy
 import com.growthook.aos.databinding.FragmentCaveSelectBottomsheetBinding
-import com.growthook.aos.domain.entity.Cave
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -35,13 +35,19 @@ class CaveSelectBottomSheet : CaveSelect() {
         setAdapter()
     }
 
-    override fun setClickAction(action: (Cave?) -> Unit) {
+    override fun moveSeed() {
         lifecycleScope.launch {
             viewModel.selectedCave.collect { cave ->
                 binding.btnHomeSelectCave.setOnClickListener {
                     cave?.let {
-                        clickBtnAction(it)
-                        dismiss()
+                        viewModel.moveSeed(toMoveSeedId, it.id)
+                        viewModel.isMove.observe(viewLifecycleOwner) { isMove ->
+                            if (isMove) {
+                                dismiss()
+                                Toast.makeText(requireContext(), "씨앗을 옮겨 심었어요", Toast.LENGTH_SHORT)
+                                    .show()
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelectBottomSheetViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelectBottomSheetViewModel.kt
@@ -6,20 +6,26 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.growthook.aos.domain.entity.Cave
 import com.growthook.aos.domain.usecase.GetCavesUseCase
+import com.growthook.aos.domain.usecase.MoveSeedUseCase
 import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class CaveSelectBottomSheetViewModel @Inject constructor(
     private val getCavesUseCase: GetCavesUseCase,
     private val getUserUseCase: GetUserUseCase,
+    private val moveSeedUseCase: MoveSeedUseCase,
 ) : ViewModel() {
 
     private val _caves = MutableLiveData<List<Cave>>()
     val caves: LiveData<List<Cave>> = _caves
+
+    private val _isMove = MutableLiveData<Boolean>()
+    val isMove: LiveData<Boolean> = _isMove
 
     val selectedCave = MutableStateFlow<Cave?>(null)
 
@@ -27,6 +33,17 @@ class CaveSelectBottomSheetViewModel @Inject constructor(
         viewModelScope.launch {
             getCavesUseCase(getUserUseCase.invoke()?.memberId ?: 0).onSuccess { caves ->
                 _caves.value = caves
+            }
+        }
+    }
+
+    fun moveSeed(seedId: Int, caveId: Int) {
+        viewModelScope.launch {
+            moveSeedUseCase(seedId, caveId).onSuccess {
+                _isMove.value = true
+            }.onFailure {
+                _isMove.value = false
+                Timber.d("씨앗 옮기기 ${it.message}")
             }
         }
     }

--- a/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelectBottomSheetViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/util/selectcave/CaveSelectBottomSheetViewModel.kt
@@ -3,13 +3,20 @@ package com.growthook.aos.util.selectcave
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.growthook.aos.domain.entity.Cave
+import com.growthook.aos.domain.usecase.GetCavesUseCase
+import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class CaveSelectBottomSheetViewModel @Inject constructor() : ViewModel() {
+class CaveSelectBottomSheetViewModel @Inject constructor(
+    private val getCavesUseCase: GetCavesUseCase,
+    private val getUserUseCase: GetUserUseCase,
+) : ViewModel() {
 
     private val _caves = MutableLiveData<List<Cave>>()
     val caves: LiveData<List<Cave>> = _caves
@@ -17,17 +24,10 @@ class CaveSelectBottomSheetViewModel @Inject constructor() : ViewModel() {
     val selectedCave = MutableStateFlow<Cave?>(null)
 
     fun getCaves() {
-        val dummyCave = listOf(
-            Cave(1, "연습용"),
-            Cave(2, "연습연습연습연습"),
-            Cave(3, "ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ"),
-            Cave(4, "동굴"),
-            Cave(5, "연습용"),
-            Cave(6, "연습연습연습연습"),
-            Cave(7, "ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ"),
-            Cave(8, "동굴"),
-        )
-
-        _caves.value = dummyCave
+        viewModelScope.launch {
+            getCavesUseCase(getUserUseCase.invoke()?.memberId ?: 0).onSuccess { caves ->
+                _caves.value = caves
+            }
+        }
     }
 }

--- a/app/src/main/java/com/growthook/aos/util/selectcave/NoApiCaveSelectBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/util/selectcave/NoApiCaveSelectBottomSheet.kt
@@ -1,0 +1,85 @@
+package com.growthook.aos.util.selectcave
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.selection.SelectionPredicates
+import androidx.recyclerview.selection.SelectionTracker
+import androidx.recyclerview.selection.StableIdKeyProvider
+import androidx.recyclerview.selection.StorageStrategy
+import com.growthook.aos.databinding.FragmentCaveSelectBottomsheetBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@AndroidEntryPoint
+class NoApiCaveSelectBottomSheet : CaveSelect() {
+    private val viewModel by viewModels<CaveSelectBottomSheetViewModel>()
+
+    private var _adapter: CaveSelectAdapter? = null
+    private val adapter
+        get() = requireNotNull(_adapter) { "adapter is null" }
+
+    override fun getFragmentBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+    ): FragmentCaveSelectBottomsheetBinding =
+        FragmentCaveSelectBottomsheetBinding.inflate(inflater, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setAdapter()
+        getSelectedCave()
+    }
+
+    fun getSelectedCave() {
+        lifecycleScope.launch {
+            viewModel.selectedCave.collect { cave ->
+                binding.btnHomeSelectCave.setOnClickListener {
+                    cave?.let {
+                        clickBtnAction(cave)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun setAdapter() {
+        _adapter = CaveSelectAdapter()
+        viewModel.getCaves()
+        viewModel.caves.observe(viewLifecycleOwner) {
+            adapter.submitList(it)
+        }
+        binding.rcvHomeSelectCave.adapter = adapter
+
+        val tracker = SelectionTracker.Builder<Long>(
+            "caveSelection",
+            binding.rcvHomeSelectCave,
+            StableIdKeyProvider(binding.rcvHomeSelectCave),
+            CaveSelectAdapter.InsightDetailsLookup(binding.rcvHomeSelectCave),
+            StorageStrategy.createLongStorage(),
+        ).withSelectionPredicate(
+            SelectionPredicates.createSelectSingleAnything(),
+        ).build()
+
+        adapter.setSelectionTracker(tracker)
+
+        tracker.addObserver(object : SelectionTracker.SelectionObserver<Long>() {
+            override fun onSelectionChanged() {
+                super.onSelectionChanged()
+
+                viewModel.selectedCave.value = adapter.getSelectedCave()
+                Timber.d("동굴 ${adapter.getSelectedCave()}")
+            }
+        })
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _adapter = null
+    }
+}

--- a/app/src/main/java/com/growthook/aos/util/selectcave/YesApiCaveSelectBottomSheet.kt
+++ b/app/src/main/java/com/growthook/aos/util/selectcave/YesApiCaveSelectBottomSheet.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
-class CaveSelectBottomSheet : CaveSelect() {
+class YesApiCaveSelectBottomSheet : CaveSelect() {
     private val viewModel by viewModels<CaveSelectBottomSheetViewModel>()
 
     private var _adapter: CaveSelectAdapter? = null
@@ -33,9 +33,10 @@ class CaveSelectBottomSheet : CaveSelect() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setAdapter()
+        moveSeed()
     }
 
-    override fun moveSeed() {
+    private fun moveSeed() {
         lifecycleScope.launch {
             viewModel.selectedCave.collect { cave ->
                 binding.btnHomeSelectCave.setOnClickListener {


### PR DESCRIPTION
## 📝 Work Description
- [x] home 뷰 api 연결
- [x] 보관함 상세 api 연결
- [x] CaveSelect api 연결

## 🌱 Issue
- closed #36 

## 💥 Screenshot


## 💬 To Reviewers
- CaveSelect 종류 두가지로 나눴습니다.
    - YesApi : api 통신하는 bottomSheet 입니다. 인사이트 조회는 이거 사용하면 될거에요
    - NoApi: api 통신 안하는 bottomSheet 입니다.  인사이트 수정 뷰에서는 YesApi 쓰면 안될거같아서 따로 만들었어요. clickActionBtn 이용해서 선택한 Cave 반환받으면 됩니다.
    - 예시) YesApi
    ```
    CaveSelect.Builder().build(
                CaveSelect.CaveSelectType.YES_API,
                insightId,
            ).show(parentFragmentManager, "select")
    ```
    - 예시) NoApi
     ```
    CaveSelect.Builder().build(
                CaveSelect.CaveSelectType.NO_API,
                viewModel.longClickInsight.value?.insightId ?: 1,
                clickBtnAction = {
                    Timber.d("home 동굴 선택 ${it.name}")
                },
            ).show(parentFragmentManager, "select")
    ```

- 삭제 alertDialog 따로 만든건 context 문제 때문입니다. 기존의 이동/삭제 bottomSheet가 dismiss 되면서 activity가 no attach 때문에 부득이하게 따로 만들었어요,,,
- memberId 추가
    - 아마 memberId도 로컬 DB에 따로 저장해야하는 걸로 알고 있어서 추가했어요 해당 코드로 불러올 수 있습니다.
    ```
     getUserUseCase.invoke().memberId
     ``` 