### PR TITLE
[FIX] 뷰 연결 마무리 / 자잘한 버그 수정

### DIFF
--- a/app/src/main/java/com/growthook/aos/presentation/actionlist/completed/CompletedActionlistAdapter.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/actionlist/completed/CompletedActionlistAdapter.kt
@@ -23,7 +23,7 @@ class CompletedActionlistAdapter(
     ) {
     class CompletedActionlistViewHolder(
         private val binding: ItemCompletedActionplanBinding,
-        private val selectedItem: (Int) -> Unit,
+        private val clickSeedDetail: (Int) -> Unit,
         private val clickReviewDetail: (Int) -> Unit,
     ) :
         RecyclerView.ViewHolder(binding.root) {
@@ -31,7 +31,7 @@ class CompletedActionlistAdapter(
             with(binding) {
                 tvCompletedActionplanTitle.text = data.content
                 tvCompletedActionplanBtnLeft.setOnClickListener {
-                    selectedItem(data.actionplanId)
+                    clickSeedDetail(data.seedId)
                 }
                 tvCompletedActionplanBtnRight.setOnClickListener {
                     clickReviewDetail(data.actionplanId)

--- a/app/src/main/java/com/growthook/aos/presentation/actionlist/completed/CompletedActionlistFragment.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/actionlist/completed/CompletedActionlistFragment.kt
@@ -1,6 +1,5 @@
 package com.growthook.aos.presentation.actionlist.completed
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -54,10 +53,13 @@ class CompletedActionlistFragment : BaseFragment<FragmentCompletedActionlistBind
     }
 
     private fun clickSeedDetail(seedId: Int) {
-        val intent =
-            Intent(requireActivity(), ActionplanInsightActivity::class.java)
-        intent.putExtra("seedId", seedId)
-        startActivity(intent)
+        startActivity(
+            ActionplanInsightActivity.getIntent(
+                requireContext(),
+                seedId,
+                "CompletedActionlistFragment",
+            ),
+        )
     }
 
     private fun clickReviewDetail(actionplanId: Int) {

--- a/app/src/main/java/com/growthook/aos/presentation/actionlist/completed/CompletedActionlistViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/actionlist/completed/CompletedActionlistViewModel.kt
@@ -26,7 +26,7 @@ class CompletedActionlistViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            memberId.value = getUserUseCase.invoke().memberId ?: 9
+            memberId.value = getUserUseCase.invoke().memberId ?: 0
         }
         getFinishedActionplans()
     }

--- a/app/src/main/java/com/growthook/aos/presentation/actionlist/proceeding/ProceedingActionlistFragment.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/actionlist/proceeding/ProceedingActionlistFragment.kt
@@ -92,6 +92,7 @@ class ProceedingActionlistFragment(private val parentFragment: ActionlistFragmen
             ActionplanInsightActivity.getIntent(
                 requireContext(),
                 seedId,
+                "ProceedingActionlistFragment",
             ),
         )
     }

--- a/app/src/main/java/com/growthook/aos/presentation/actionlist/proceeding/ProceedingActionlistViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/actionlist/proceeding/ProceedingActionlistViewModel.kt
@@ -42,7 +42,7 @@ class ProceedingActionlistViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            memberId.value = getUserUseCase.invoke().memberId ?: 9
+            memberId.value = getUserUseCase.invoke().memberId ?: 0
         }
         getDoingActionplans()
     }

--- a/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/cavedetail/CaveDetailActivity.kt
@@ -211,7 +211,7 @@ class CaveDetailActivity : BaseActivity<ActivityCaveDetailBinding>({
                     },
                 ).show(supportFragmentManager, InsightMenuBottomsheet.DELETE_DIALOG)
         } else if (item.hasActionPlan) {
-            startActivity(ActionplanInsightActivity.getIntent(this, item.seedId))
+            startActivity(ActionplanInsightActivity.getIntent(this, item.seedId, "CaveDetailActivity"))
         } else {
             startActivity(NoActionplanInsightActivity.getIntent(this, item.seedId))
         }

--- a/app/src/main/java/com/growthook/aos/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/home/HomeFragment.kt
@@ -218,7 +218,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
                     },
                 ).show(parentFragmentManager, InsightMenuBottomsheet.DELETE_DIALOG)
         } else if (item.hasActionPlan) {
-            startActivity(ActionplanInsightActivity.getIntent(requireContext(), item.seedId))
+            startActivity(ActionplanInsightActivity.getIntent(requireContext(), item.seedId, "HomeFragment"))
         } else {
             startActivity(NoActionplanInsightActivity.getIntent(requireContext(), item.seedId))
         }

--- a/app/src/main/java/com/growthook/aos/presentation/insight/actionplan/ActionplanAdapter.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/insight/actionplan/ActionplanAdapter.kt
@@ -10,14 +10,12 @@ import com.growthook.aos.R
 import com.growthook.aos.databinding.ItemActionplanBinding
 import com.growthook.aos.domain.entity.Actionplan
 import com.growthook.aos.util.extension.ItemDiffCallback
-import timber.log.Timber
 
 class ActionplanAdapter(
     private val clickModify: (Int) -> Unit,
     private val clickDelete: (Int) -> Unit,
     private val clickComplete: (Int) -> Unit,
-    private val clickScrapActionplan: (Int) -> Unit,
-    private val isScraped: () -> Boolean,
+    private val clickScrapActionplan: (Int, Boolean) -> Unit,
 ) :
     ListAdapter<Actionplan, ActionplanAdapter.ActionplanViewHolder>(
         ItemDiffCallback<Actionplan>(
@@ -25,21 +23,24 @@ class ActionplanAdapter(
             onItemsTheSame = { old, new -> old.actionplanId == new.actionplanId },
         ),
     ) {
+    private var isSeedSelectedCallback: ((Int, Boolean) -> Unit)? = null
+
+    fun setSeedSelectedCallback(callback: ((Int, Boolean) -> Unit)?) {
+        isSeedSelectedCallback = callback
+    }
 
     inner class ActionplanViewHolder(
         private val binding: ItemActionplanBinding,
         private val clickModify: (Int) -> Unit,
         private val clickDelete: (Int) -> Unit,
         private val clickComplete: (Int) -> Unit,
-        private val clickScrapActionplan: (Int) -> Unit,
-        private val isScraped: () -> Boolean,
+        private val clickScrapActionplan: (Int, Boolean) -> Unit,
     ) :
         RecyclerView.ViewHolder(binding.root) {
         private var isItemSelected = false
         private var isSeedSelected = false
         fun onBind(data: Actionplan) {
             with(binding) {
-                Timber.d("isScraped: ${data.isScraped}")
                 tvActionplanTitle.text = data.content
                 ivActionplanMenu.setOnClickListener {
                     isItemSelected = !isItemSelected
@@ -67,7 +68,7 @@ class ActionplanAdapter(
                 }
                 ivActionplan.setOnClickListener {
                     isSeedSelected = !isSeedSelected
-                    clickScrapActionplan(data.actionplanId)
+                    clickScrapActionplan(data.actionplanId, isSeedSelected)
                     if (isSeedSelected) {
                         ivActionplan.setImageResource(R.drawable.ic_scrap_selected)
                     } else {
@@ -111,7 +112,6 @@ class ActionplanAdapter(
             clickDelete,
             clickComplete,
             clickScrapActionplan,
-            isScraped,
         )
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/insight/actionplan/ActionplanInsightActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/insight/actionplan/ActionplanInsightActivity.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.growthook.aos.R
 import com.growthook.aos.databinding.ActivityActionplanInsightBinding
+import com.growthook.aos.presentation.MainActivity
 import com.growthook.aos.presentation.insight.actionplan.ActionplanInsightViewModel.Event
 import com.growthook.aos.util.base.BaseActivity
 import com.growthook.aos.util.base.BaseAlertDialog
@@ -28,28 +29,54 @@ class ActionplanInsightActivity :
 
     private val viewModel by viewModels<ActionplanInsightViewModel>()
     private var seedId: Int = 0
+    private var previousView: String = ""
+    private var isSeedSelected = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        getSeedIdFromHome()
+        getIntentValue()
+        setVisibilityBtn()
         initActionplanAdapter()
         subscribe()
         foldInsightContent()
         clickeListeners()
     }
 
-    private fun getSeedIdFromHome() {
+    private fun getIntentValue() {
         seedId = intent.getIntExtra(SEED_ID, 0)
+        previousView = intent.getStringExtra(PRE_STATE) ?: "nulll"
         Timber.d("ActionplanInsightActivity seed id $seedId")
         viewModel.seedId = seedId
         viewModel.getSeedDetail()
         viewModel.getActionplans()
     }
 
+    private fun setVisibilityBtn() {
+        when (previousView) {
+            "AddActionplanActivity" -> {
+                binding.ivActionplanInsightClose.visibility = View.VISIBLE
+                binding.ivActionplanInsightBack.visibility = View.INVISIBLE
+            }
+        }
+    }
+
     private fun subscribe() {
         observeSeedDetail()
         observeActionplanData()
         observeEvent()
+    }
+
+    private fun clickInsightSeed() {
+        binding.ivActionplanInsightSeed.setOnClickListener {
+            isSeedSelected = !isSeedSelected
+            viewModel.changeSeedScrap(seedId)
+            if (isSeedSelected) {
+                binding.ivActionplanInsightSeed.setImageResource(R.drawable.ic_scrap_selected)
+                Toast.makeText(this, "씨앗이 스크랩 되었어요", Toast.LENGTH_SHORT).show()
+            } else {
+                binding.ivActionplanInsightSeed.setImageResource(R.drawable.ic_scrap_unselected)
+            }
+        }
     }
 
     private fun initActionplanAdapter() {
@@ -59,7 +86,6 @@ class ActionplanInsightActivity :
                 ::clickDeleteMenu,
                 ::clickCompleteBtn,
                 ::clickScrapActionplan,
-                ::isScraped,
             )
         binding.rcvActionplanInsight.adapter = _actionplanAdapter
     }
@@ -130,7 +156,7 @@ class ActionplanInsightActivity :
                 tvActionplanInsightChip.text = seed?.caveName
                 "D-${seed?.remainingDays}".also { tvActionplanInsightDday.text = it }
 
-                if (seed.content == null) {
+                if (seed.content.isNullOrEmpty()) {
                     clActionplanInsightMemoEmpty.visibility = View.VISIBLE
                     scvActionplanInsightContent.visibility = View.INVISIBLE
                 } else {
@@ -161,6 +187,17 @@ class ActionplanInsightActivity :
     private fun clickeListeners() {
         clickBackBtn()
         clickAddActionplan()
+        clickCloseBtn()
+        clickInsightSeed()
+    }
+
+    private fun clickCloseBtn() {
+        binding.ivActionplanInsightClose.setOnClickListener {
+            val intent = Intent(this, MainActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
+            finish()
+        }
     }
 
     private fun clickBackBtn() {
@@ -169,8 +206,11 @@ class ActionplanInsightActivity :
         }
     }
 
-    private fun clickScrapActionplan(actionplanId: Int) {
-        viewModel.changeScrap(actionplanId)
+    private fun clickScrapActionplan(actionplanId: Int, isSeedSelected: Boolean) {
+        viewModel.changeActionplanScrap(actionplanId)
+        if (isSeedSelected) {
+            Toast.makeText(this, "액션이 스크랩 되었어요", Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun clickAddActionplan() {
@@ -184,16 +224,6 @@ class ActionplanInsightActivity :
                 clickNoWritingBtn = {},
             ).show(supportFragmentManager, "add actionplan dialog")
         }
-    }
-
-    private fun isScraped(): Boolean {
-        var isScraped = false
-        viewModel.event.flowWithLifecycle(lifecycle).onEach { event ->
-            if (event == Event.ScrapSuccess) {
-                isScraped = true
-            }
-        }.launchIn(lifecycleScope)
-        return isScraped
     }
 
     private fun observeEvent() {
@@ -230,9 +260,9 @@ class ActionplanInsightActivity :
                         ).show(supportFragmentManager, "get thook dialog")
                 }
 
-                is Event.ScrapSuccess -> {
-                    Toast.makeText(this, "액션플랜 스크랩 완료!", Toast.LENGTH_SHORT).show()
-                }
+//                is Event.ScrapSuccess -> {
+//                    Toast.makeText(this, "액션플랜 스크랩 완료!", Toast.LENGTH_SHORT).show()
+//                }
 
                 else -> {}
             }
@@ -248,10 +278,12 @@ class ActionplanInsightActivity :
         const val DELETE_DIALOG = "delete dialog"
         private const val TAG = "tag"
         private const val SEED_ID = "seedId"
+        private const val PRE_STATE = "preState"
 
-        fun getIntent(context: Context, seedId: Int): Intent {
+        fun getIntent(context: Context, seedId: Int, preState: String): Intent {
             return Intent(context, ActionplanInsightActivity::class.java).apply {
                 putExtra(SEED_ID, seedId)
+                putExtra(PRE_STATE, preState)
             }
         }
     }

--- a/app/src/main/java/com/growthook/aos/presentation/insight/actionplan/ActionplanInsightViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/insight/actionplan/ActionplanInsightViewModel.kt
@@ -16,6 +16,7 @@ import com.growthook.aos.domain.usecase.actionplan.PostActionplansUseCase
 import com.growthook.aos.domain.usecase.actionplan.ScrapActionplanUseCase
 import com.growthook.aos.domain.usecase.review.PostReviewUseCase
 import com.growthook.aos.domain.usecase.seeddetail.GetSeedUseCase
+import com.growthook.aos.util.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -47,6 +48,20 @@ class ActionplanInsightViewModel @Inject constructor(
 
     private val _event = MutableStateFlow<Event>(Event.Default)
     val event: MutableStateFlow<Event> = _event
+
+    // TODO util Event 네이밍 수정
+    private val _isSeedScrapedSuccess = MutableLiveData<com.growthook.aos.util.Event<Boolean>>()
+    val isSeedScrapedSuccess: LiveData<com.growthook.aos.util.Event<Boolean>> = _isSeedScrapedSuccess
+
+    fun changeSeedScrap(seedId: Int) {
+        viewModelScope.launch {
+            scrapSeedUseCase.invoke(seedId).onSuccess {
+                _isSeedScrapedSuccess.value = Event(true)
+            }.onFailure {
+                _isSeedScrapedSuccess.value = Event(false)
+            }
+        }
+    }
 
     fun postActionplan(seedId: Int, actionplan: String) {
         viewModelScope.launch {
@@ -140,7 +155,7 @@ class ActionplanInsightViewModel @Inject constructor(
         }
     }
 
-    fun changeScrap(actionplanId: Int) {
+    fun changeActionplanScrap(actionplanId: Int) {
         viewModelScope.launch {
             scrapActionplanUseCase.invoke(actionplanId).onSuccess {
                 _event.value = Event.ScrapSuccess

--- a/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/InsightMenuBottomsheet.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/InsightMenuBottomsheet.kt
@@ -9,7 +9,6 @@ import android.widget.Toast
 import androidx.fragment.app.activityViewModels
 import com.growthook.aos.R
 import com.growthook.aos.databinding.FragmentInsightMenuBottomsheetBinding
-import com.growthook.aos.presentation.MainActivity
 import com.growthook.aos.presentation.insight.noactionplan.NoActionplanInsightViewModel.Event
 import com.growthook.aos.presentation.insight.noactionplan.model.SeedModifyIntent
 import com.growthook.aos.util.base.BaseAlertDialog
@@ -94,8 +93,6 @@ class InsightMenuBottomsheet :
                 isTipVisility = false,
                 negativeAction = {
                     viewModel.deleteSeed()
-                    val intent = Intent(requireActivity(), MainActivity::class.java)
-                    startActivity(intent)
                     dismiss()
                 },
                 positiveAction = {},
@@ -116,7 +113,6 @@ class InsightMenuBottomsheet :
 
     companion object {
         const val DELETE_DIALOG = "delete dialog"
-        private const val DUMMY_SEED = 113
         const val SEED_MODIFY_INTENT = "SEED_MODIFY_INTENT"
         const val CAVE_SELECT_DIALOG = "cave select dialog"
     }

--- a/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/NoActionplanInsightActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/NoActionplanInsightActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.activity.viewModels
 import com.growthook.aos.R
 import com.growthook.aos.databinding.ActivityNoActionplanInsightBinding
@@ -19,11 +20,13 @@ class NoActionplanInsightActivity :
     private val viewModel by viewModels<NoActionplanInsightViewModel>()
     private var seedId: Int = 0
     private lateinit var seedUrl: String
+    private var isSeedSelected = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         getSeedIdFromHome()
         observeSeedDetail()
+        observeEvent()
         setClickListeners()
     }
 
@@ -70,6 +73,20 @@ class NoActionplanInsightActivity :
         clickAddAction()
         clickBackBtn()
         clickUrl()
+        clickInsightSeed()
+    }
+
+    private fun clickInsightSeed() {
+        binding.ivNoactionInsightSeed.setOnClickListener {
+            isSeedSelected = !isSeedSelected
+            viewModel.changeSeedScrap(seedId)
+            if (isSeedSelected) {
+                binding.ivNoactionInsightSeed.setImageResource(R.drawable.ic_scrap_selected)
+                Toast.makeText(this, "씨앗 스크랩 완료", Toast.LENGTH_SHORT).show()
+            } else {
+                binding.ivNoactionInsightSeed.setImageResource(R.drawable.ic_scrap_unselected)
+            }
+        }
     }
 
     private fun clickMenu() {
@@ -95,6 +112,18 @@ class NoActionplanInsightActivity :
         binding.tvNoactionInsightUrl.setOnClickListener {
             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(seedUrl))
             startActivity(intent)
+        }
+    }
+
+    private fun observeEvent() {
+        viewModel.event.observe(this) { event ->
+            when (event) {
+                NoActionplanInsightViewModel.Event.DeleteSeedSuccess -> {
+                    finish()
+                }
+
+                else -> {}
+            }
         }
     }
 

--- a/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/NoActionplanInsightViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/NoActionplanInsightViewModel.kt
@@ -10,9 +10,10 @@ import com.growthook.aos.domain.entity.Seed
 import com.growthook.aos.domain.usecase.DeleteSeedUseCase
 import com.growthook.aos.domain.usecase.GetCavesUseCase
 import com.growthook.aos.domain.usecase.MoveSeedUseCase
+import com.growthook.aos.domain.usecase.ScrapSeedUseCase
 import com.growthook.aos.domain.usecase.local.GetUserUseCase
 import com.growthook.aos.domain.usecase.seeddetail.GetSeedUseCase
-import com.growthook.aos.domain.usecase.seeddetail.ModifySeedUseCase
+import com.growthook.aos.util.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -24,8 +25,8 @@ class NoActionplanInsightViewModel @Inject constructor(
     private val getSeedUseCase: GetSeedUseCase,
     private val getCavesUseCase: GetCavesUseCase,
     private val deleteSeedUseCase: DeleteSeedUseCase,
-    private val modifySeedUseCase: ModifySeedUseCase,
     private val moveSeedUseCase: MoveSeedUseCase,
+    private val scrapSeedUseCase: ScrapSeedUseCase,
 ) :
     ViewModel() {
     private val _caves = MutableLiveData<List<Cave>>()
@@ -47,19 +48,22 @@ class NoActionplanInsightViewModel @Inject constructor(
 
     private val memberId = MutableLiveData<Int>(0)
 
+    // TODO util Event 네이밍 수정
+    private val _isScrapedSuccess = MutableLiveData<com.growthook.aos.util.Event<Boolean>>()
+    val isScrapedSuccess: LiveData<com.growthook.aos.util.Event<Boolean>> = _isScrapedSuccess
+
     init {
         viewModelScope.launch {
             memberId.value = getUserUseCase.invoke().memberId ?: 0
         }
     }
 
-    fun moveSeed(seedId: Int, caveId: Int) {
+    fun changeSeedScrap(seedId: Int) {
         viewModelScope.launch {
-            moveSeedUseCase(seedId, caveId).onSuccess {
-                _isMove.value = true
+            scrapSeedUseCase.invoke(seedId).onSuccess {
+                _isScrapedSuccess.value = Event(true)
             }.onFailure {
-                _isMove.value = false
-                Timber.d("씨앗 옮기기 ${it.message}")
+                _isScrapedSuccess.value = Event(false)
             }
         }
     }

--- a/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/add/AddActionplanActivity.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/add/AddActionplanActivity.kt
@@ -142,7 +142,14 @@ class AddActionplanActivity :
         viewModel.event.observe(this) { event ->
             when (event) {
                 is Event.PostSuccess -> {
-                    startActivity(ActionplanInsightActivity.getIntent(this, seedId))
+                    startActivity(
+                        ActionplanInsightActivity.getIntent(
+                            this,
+                            seedId,
+                            "AddActionplanActivity",
+                        ),
+                    )
+                    finish()
                 }
 
                 is Event.PostFailed -> {

--- a/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/add/AddActionplanViewModel.kt
+++ b/app/src/main/java/com/growthook/aos/presentation/insight/noactionplan/add/AddActionplanViewModel.kt
@@ -59,9 +59,11 @@ class AddActionplanViewModel @Inject constructor(
     }
 
     fun addItem(item: String) {
-        val currentItems = _actionplanList.value.orEmpty().toMutableList()
-        currentItems.add(0, item)
-        _actionplanList.value = currentItems
+        if (!item.isNullOrBlank()) {
+            val currentItems = _actionplanList.value.orEmpty().toMutableList()
+            currentItems.add(0, item)
+            _actionplanList.value = currentItems
+        }
     }
 
     fun updateItem(position: Int, text: String) {

--- a/app/src/main/res/layout/activity_actionplan_insight.xml
+++ b/app/src/main/res/layout/activity_actionplan_insight.xml
@@ -36,6 +36,18 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/iv_actionplan_insight_back" />
 
+        <ImageView
+            android:id="@+id/iv_actionplan_insight_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:layout_marginTop="20dp"
+            android:src="@drawable/ic_close"
+            android:visibility="invisible"
+            app:layout_constraintDimensionRatio="1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -199,7 +211,7 @@
                     android:layout_marginTop="8dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/iv_actionplan_insight_empty"
+                    app:layout_constraintTop_toBottomOf="@id/iv_actionplan_insight_empty"
                     android:textColor="@color/Gray200" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
@@ -214,7 +226,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tv_actionplan_insight_date">
-
                 <TextView
                     android:id="@+id/tv_actionplan_insight_content"
                     style="@style/body3_reg"

--- a/app/src/main/res/layout/item_actionplan_edittext.xml
+++ b/app/src/main/res/layout/item_actionplan_edittext.xml
@@ -12,6 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="18dp"
         app:boxBackgroundColor="@color/Gray900"
+        style="@style/TextInputLayoutStyle"
         app:counterEnabled="true"
         app:counterMaxLength="40"
         app:endIconMode="clear_text"


### PR DESCRIPTION
## 📝 Work Description
- [x] 인사이트 조회 -> 삭제 -> 동굴 상세 보기 연결
- [x] 액션플랜 추가뷰 x 버튼 변경
- [x] 액션 더하기 후 뒤로가기 누르면 홈화면 가게끔
- [x] 완료된 액션플랜 씨앗보기 seedId 수정 
- [x] 액션플랜 쑥 얻기 로직 확인
- [x] 액션플랜 리스트 내에 빈 원소 있는지 검사하는 로직 추가
- [x] 인사이트 조회 메모 엠티 뷰 추가
- [x] 액션플랜&인사이트 스크랩 전환 클릭 로직 수정

## 🌱 Issue
- closed #66 

## 💥 Screenshot


## 💬 To Reviewers
